### PR TITLE
Temporarily override numpy pins in recipe (work around conda-build bug)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,20 +11,6 @@ c_compiler:            # [win]
   - vs2019             # [win]
 cxx_compiler:          # [win]
   - vs2019             # [win]
-numpy:
-  # python 3.7-3.9
-  - 1.17    # [linux64 or ppc64le or (osx and x86) or win]
-  - 1.17    # [linux64 or ppc64le or (osx and x86) or win]
-  - 1.17    # [linux64 or ppc64le or (osx and x86) or win]
-  # python 3.7-3.9
-  - 1.19    # [aarch64 or s390x]
-  - 1.19    # [aarch64 or s390x]
-  - 1.19    # [aarch64 or s390x]
-  # python 3.8-3.9
-  - 1.19    # [osx and arm64]
-  - 1.19    # [osx and arm64]
-  # python 3.10
-  - 1.21
 pytorch_variant:
   - cpu
 # - gpu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,8 +108,12 @@ requirements:
     - cffi
     - future
     - libuv                           # [win]
-    # The test suite uses features only available in numpy 1.17+.
-    - numpy
+    # The test suite uses features only available in numpy 1.17+. We override
+    # numpy pinnings here due to a bug in conda-build mishandling zip key
+    # overrides in local cbc.yaml files. Remove and/or adjust this on the next
+    # upgrade.
+    - numpy >=1.17                    # [not (osx and arm64) and py<310 ]
+    - numpy                           # [    (osx and arm64) or  py>=310]
     - pip
     - pkg-config                      # [unix]
     - python


### PR DESCRIPTION
This was reviewed here: https://github.com/AnacondaRecipes/pytorch-feedstock/pull/2. But needs a rebuild with a small work-around for conda-builds mishandling of zip-key overrides.