### PR TITLE
Fix to address openmp runtime bug

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,7 @@
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
+aggregate_check: false
+
+channels:
+  - dp_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,7 +4,4 @@
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
-aggregate_check: false
 
-channels:
-  - dp_test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -144,11 +144,6 @@ else
             export BLAS="MKL"
             export USE_MKL=1
             export USE_MKLDNN=1
-            # Pytorch wants libomp.dylib, but intel-openmp, pulled in for the mkl variant, only provides libiomp5.dylib.
-            # So we create a symlink to it.
-            pushd "${PREFIX}/lib"
-            [[ -f libomp.dylib ]] || ln -s libiomp5.dylib libomp.dylib
-            popd
             ;;
         openblas)
             export BLAS="OpenBLAS"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -144,6 +144,11 @@ else
             export BLAS="MKL"
             export USE_MKL=1
             export USE_MKLDNN=1
+            # Pytorch wants libomp.dylib, but intel-openmp, pulled in for the mkl variant, only provides libiomp5.dylib.
+            # So we create a symlink to it.
+            pushd "${PREFIX}/lib"
+            [[ -f libomp.dylib ]] || ln -s libiomp5.dylib libomp.dylib
+            popd
             ;;
         openblas)
             export BLAS="OpenBLAS"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,4 @@
-# MKL is only available on intel platforms, and it's faster on those platforms than openBLAS so we use it there.
-blas_impl:
-  - mkl                # [x86]
-  - openblas           # [not x86]
+# The blas_impl is specified in the aggregate conda_build_config.yaml
 # We get "relocation truncated to fit" with an associated linker error on PPC if we don't pin the compiler version
 c_compiler_version:    # [(linux and ppc64le)]
   - 8                  # [(linux and ppc64le)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,9 @@
-# The blas_impl is specified in the aggregate conda_build_config.yaml
+# We don't build using mkl on osx-64 for now. The openmp libraries are conflicting between different packages, leading
+# to .dylib loading errors. It needs a proper clean up before we can support it.
+# This is the same as the aggregate cbc.yaml otherwise
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas                   # [not win]
 # We get "relocation truncated to fit" with an associated linker error on PPC if we don't pin the compiler version
 c_compiler_version:    # [(linux and ppc64le)]
   - 8                  # [(linux and ppc64le)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,7 +100,9 @@ requirements:
     - m2-patch                        # [win]
     - python ={{PY_VER}}
     - ninja
-    - llvm-openmp                     # [osx]
+    # This has a strong run_export so we don't need to put it in `host` or `run`
+    # We use llvm-openmp for openblas variants on osx.
+    - llvm-openmp                     # [osx and not (blas_impl == "mkl")]
     # Keep libprotobuf here so that a compatibile version
     # of protobuf is installed between build and host
     # Unvendoring protobuf doesn't work properly for windows
@@ -119,11 +121,10 @@ requirements:
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
     - openblas                        # [blas_impl == "openblas"]
     # OpenMP
-    # So we pull in the same versions of mkl and intel-openmp: intel aligns the versions
-    # We use llvm-openmp always on osx; for other platforms, we use intel-openmp to support mkl, which is also intel.
+    # We pull in the same versions of mkl and intel-openmp: intel aligns the versions
+    # We use intel-openmp for all mkl variants.
     # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
-    - intel-openmp   {{ mkl }}        # [(blas_impl == "mkl") and not osx]
-    - llvm-openmp                     # [osx]
+    - intel-openmp   {{ mkl }}        # [blas_impl == "mkl"]
     # Other requirements
     - cffi
     - future
@@ -151,8 +152,7 @@ requirements:
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
     - libopenblas                     # [blas_impl == "openblas"]
     # OpenMP
-    - {{ pin_compatible('intel-openmp') }}   # [(blas_impl == "mkl") and not osx]
-    - llvm-openmp                            # [osx]
+    - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
     # GPU requirements
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
     - {{ pin_compatible('cudnn') }}                       # [pytorch_variant == "gpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -201,6 +201,9 @@ test:
     # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/24
     - pip check
     - python -c "import torch; print(torch.__version__)"
+    # We have had issues with openmp .dylibs being doubly loaded in certain cases. These two tests catch those issues
+    - python -c "import torch; import numpy"
+    - python -c "import numpy; import torch"
     # distributed support is enabled by default on linux; for mac, we enable it manually in build.sh
     - python -c "import torch; assert torch.distributed.is_available()"        # [linux or osx]
     - python -c "import torch; assert torch.backends.mkldnn.m.is_available()"  # [x86 and cuda_compiler_version == "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,7 +100,7 @@ requirements:
     - m2-patch                        # [win]
     - python ={{PY_VER}}
     - ninja
-    - llvm-openmp                     # [osx]
+    - llvm-openmp                     # [osx and arm64]
     # Keep libprotobuf here so that a compatibile version
     # of protobuf is installed between build and host
     # Unvendoring protobuf doesn't work properly for windows

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ build:
   skip: True  # [py<37]
   # TODO: note that at the moment we only use CUDA backend, e.g. would be different for mac
   string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
-  string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
+  string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]
   detect_binary_files_with_prefix: False
   missing_dso_whitelist:
     # It is not clear why conda-build cannot figure these out.
@@ -100,7 +100,7 @@ requirements:
     - m2-patch                        # [win]
     - python ={{PY_VER}}
     - ninja
-    - llvm-openmp                     # [osx and arm64]
+    - llvm-openmp                     # [osx]
     # Keep libprotobuf here so that a compatibile version
     # of protobuf is installed between build and host
     # Unvendoring protobuf doesn't work properly for windows
@@ -119,8 +119,11 @@ requirements:
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
     - openblas                        # [blas_impl == "openblas"]
     # OpenMP
-    - intel-openmp                    # [(osx or win) and x86]
-    - llvm-openmp                     # [osx and arm64]
+    # So we pull in the same versions of mkl and intel-openmp: intel aligns the versions
+    # We use llvm-openmp always on osx; for other platforms, we use intel-openmp to support mkl, which is also intel.
+    # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
+    - intel-openmp   {{ mkl }}        # [(blas_impl == "mkl") and not osx]
+    - llvm-openmp                     # [osx]
     # Other requirements
     - cffi
     - future
@@ -148,8 +151,8 @@ requirements:
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
     - libopenblas                     # [blas_impl == "openblas"]
     # OpenMP
-    - intel-openmp                    # [(osx or win) and x86]
-    - llvm-openmp                     # [osx and arm64]
+    - {{ pin_compatible('intel-openmp') }}   # [(blas_impl == "mkl") and not osx]
+    - llvm-openmp                            # [osx]
     # GPU requirements
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
     - {{ pin_compatible('cudnn') }}                       # [pytorch_variant == "gpu"]
@@ -165,6 +168,7 @@ requirements:
     - numpy >=1.19,<2  # [py<=39]
     - python
     - typing-extensions
+    # To stop the compiler pulling in an openmp implementation itself
     - _openmp_mutex                   # [linux]
     - pyyaml
     - magma                           # [pytorch_variant == "gpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,6 @@ build:
   # to resource constraints (the build is very memory intensive). Manual builds
   # may or may not go through, your mileage may vary.
   skip: True  # [py<37]
-  skip: True  # [not osx]
   # TODO: note that at the moment we only use CUDA backend, e.g. would be different for mac
   string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ build:
   # to resource constraints (the build is very memory intensive). Manual builds
   # may or may not go through, your mileage may vary.
   skip: True  # [py<37]
+  skip: True  # [not osx]
   # TODO: note that at the moment we only use CUDA backend, e.g. would be different for mac
   string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]


### PR DESCRIPTION
This is due to a conflict in libraries providing openmp .dylibs, on `osx-64`, using `mkl` as the backend. We have two: `llvm-openmp` and `intel-openmp`. On linux, we have a package`_openmp_mutex` which prevents both being installed into the same environment. However, on `osx-64` we don't have such a mutex, and both libraries can be installed into the environment. The packages also set up symlinks between different versions of the .dylib, leading to errors where the .dylib is initialised twice in certain cases.

This change adds tests to catch the error, and also disables `mkl` build on `osx-64`. We should implement a mutex and clean up the installation and handling of these libraries in general before we support `mkl` on `osx`.

Note that build number 1 hasn't been released yet, so we don't need to bump it.

Also please note that the customer is asking for this with some urgency, so if the reviewer could forgo linter checks for the time being that would be helpful.