### PR TITLE
osx-arm64 GPU v1.13.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -158,6 +158,7 @@ else
 
 fi
 
+export USE_MPS=1
 
 # The build needs a lot of memory. Limit to 4 CPUs to take it easy on builders.
 export MAX_JOBS=$((${CPU_COUNT} > 4 ? 4 : ${CPU_COUNT}))

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -100,40 +100,52 @@ export PYTORCH_BUILD_NUMBER=$PKG_BUILDNUM
 # the backend for CPU builds.
 if [[ ${pytorch_variant} = "gpu" ]]; then
 
-    export USE_CUDA=1
+    if [[ "$OSTYPE" == "darwin"* ]]; then
 
-    # Warning from pytorch v1.12.1: In the future we will require one to 
-    # explicitly pass TORCH_CUDA_ARCH_LIST to cmake instead of implicitly
-    # setting it as an env variable.
-    #
-    # Use PTX with the latest CUDA architecture
-    if [[ ${cudatoolkit} == 9.0* ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;7.0+PTX"
-    elif [[ ${cudatoolkit} == 9.2* ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0+PTX"
-    elif [[ ${cudatoolkit} == 10.* ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5+PTX"
-    elif [[ ${cudatoolkit} == 11.0* ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0+PTX"
-    elif [[ ${cudatoolkit} == 11.1 ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
-    elif [[ ${cudatoolkit} == 11.2 ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
-    elif [[ ${cudatoolkit} == 11.3 ]]; then
-        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+        ###### Mac - MPS backend ######
+        export USE_MPS=1
+
+        # Required to make the right SDK found on Anaconda's CI system. Ideally should be fixed in the CI or conda-build
+        export DEVELOPER_DIR=/Library/Developer/CommandLineTools
     else
-        echo "No CUDA architecture list exists for cuda_compiler_version==${cudatoolkit}"
-        echo "in build.sh. Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one."
-        exit 1
-    fi
 
-    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
-    export NCCL_ROOT_DIR=/usr/local/cuda
-    export USE_STATIC_NCCL=1
-    export CUDACXX=/usr/local/cuda/bin/nvcc
-    export CUDAHOSTCXX="${CXX}"                # If this isn't included, CUDA will use the system compiler to compile host
-                                               # files, rather than the one in the conda environment, resulting in compiler errors
-    export MAGMA_HOME="${PREFIX}"
+        ###### Linux - CUDA backend ######
+        export USE_CUDA=1
+
+        # Warning from pytorch v1.12.1: In the future we will require one to 
+        # explicitly pass TORCH_CUDA_ARCH_LIST to cmake instead of implicitly
+        # setting it as an env variable.
+        #
+        # Use PTX with the latest CUDA architecture
+        if [[ ${cudatoolkit} == 9.0* ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;7.0+PTX"
+        elif [[ ${cudatoolkit} == 9.2* ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0+PTX"
+        elif [[ ${cudatoolkit} == 10.* ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5+PTX"
+        elif [[ ${cudatoolkit} == 11.0* ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0+PTX"
+        elif [[ ${cudatoolkit} == 11.1 ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+        elif [[ ${cudatoolkit} == 11.2 ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+        elif [[ ${cudatoolkit} == 11.3 ]]; then
+            export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+        else
+            echo "No CUDA architecture list exists for cuda_compiler_version==${cudatoolkit}"
+            echo "in build.sh. Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one."
+            exit 1
+        fi
+
+        export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+        export NCCL_ROOT_DIR=/usr/local/cuda
+        export USE_STATIC_NCCL=1
+        export CUDACXX=/usr/local/cuda/bin/nvcc
+        export CUDAHOSTCXX="${CXX}"                # If this isn't included, CUDA will use the system compiler to compile host
+                                                # files, rather than the one in the conda environment, resulting in compiler errors
+        export MAGMA_HOME="${PREFIX}"
+
+    fi
 
 else
 
@@ -158,8 +170,7 @@ else
 
 fi
 
-export USE_MPS=1
-export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+
 
 # The build needs a lot of memory. Limit to 4 CPUs to take it easy on builders.
 export MAX_JOBS=$((${CPU_COUNT} > 4 ? 4 : ${CPU_COUNT}))

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -159,6 +159,7 @@ else
 fi
 
 export USE_MPS=1
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
 
 # The build needs a lot of memory. Limit to 4 CPUs to take it easy on builders.
 export MAX_JOBS=$((${CPU_COUNT} > 4 ? 4 : ${CPU_COUNT}))

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,6 +12,11 @@ cxx_compiler:          # [win]
   - vs2019             # [win]
 pytorch_variant:
   - cpu
+MACOSX_SDK_VERSION:          # [osx]
+  - 12.3                    # [osx]
+CONDA_BUILD_SYSROOT:         # [osx]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [osx and arm64]
+
 ################# For GPU building, uncomment everything below and comment out the two lines above this #############
 ## We currently haven't implemented and tested GPU acceleration on OSX (although it's possible for osx-arm64).
 ## This is also the case for linux powerPC and ARM cores.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,26 +10,26 @@ c_compiler:            # [win]
   - vs2019             # [win]
 cxx_compiler:          # [win]
   - vs2019             # [win]
-pytorch_variant:
-  - cpu
+# pytorch_variant:
+#   - cpu
 
-################# For GPU building, uncomment everything below and comment out the two lines above this #############
-## We currently support GPUs on linux-64 (with a CUDA backend) and osx-arm64 (with an MPS backend)
-## We don't support it on Windows, because we need magma as a dependency and there have been significant issues getting
-## CMake to build magma with CUDA support.
-## For linux-64, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
-## https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html
-#pytorch_variant:       # [(linux and x86_64) or (osx and arm64)]
-#  - gpu                # [(linux and x86_64) or (osx and arm64)]
-#c_compiler_version:    # [(linux and x86_64)]
-#  - 9                  # [(linux and x86_64)]
-#cxx_compiler_version:  # [(linux and x86_64)]
-#  - 9                  # [(linux and x86_64)]
-#cudatoolkit:           # [(linux and x86_64)]
-#  - 11.3               # [(linux and x86_64)]
-#cudnn:                 # [(linux and x86_64)]
-#  - 8                  # [(linux and x86_64)]
-#MACOSX_SDK_VERSION:    # [(osx and arm64)]
-#  - 12.3               # [(osx and arm64)]
-#CONDA_BUILD_SYSROOT:   # [(osx and arm64)]
-#  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [(osx and arm64)]
+################ For GPU building, uncomment everything below and comment out the two lines above this #############
+# We currently support GPUs on linux-64 (with a CUDA backend) and osx-arm64 (with an MPS backend)
+# We don't support it on Windows, because we need magma as a dependency and there have been significant issues getting
+# CMake to build magma with CUDA support.
+# For linux-64, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
+# https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html
+pytorch_variant:       # [(linux and x86_64) or (osx and arm64)]
+ - gpu                # [(linux and x86_64) or (osx and arm64)]
+c_compiler_version:    # [(linux and x86_64)]
+ - 9                  # [(linux and x86_64)]
+cxx_compiler_version:  # [(linux and x86_64)]
+ - 9                  # [(linux and x86_64)]
+cudatoolkit:           # [(linux and x86_64)]
+ - 11.3               # [(linux and x86_64)]
+cudnn:                 # [(linux and x86_64)]
+ - 8                  # [(linux and x86_64)]
+MACOSX_SDK_VERSION:    # [(osx and arm64)]
+ - 12.3               # [(osx and arm64)]
+CONDA_BUILD_SYSROOT:   # [(osx and arm64)]
+ - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [(osx and arm64)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,21 +12,15 @@ cxx_compiler:          # [win]
   - vs2019             # [win]
 pytorch_variant:
   - cpu
-MACOSX_SDK_VERSION:          # [osx]
-  - 12.3                    # [osx]
-CONDA_BUILD_SYSROOT:         # [osx]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [osx and arm64]
 
 ################# For GPU building, uncomment everything below and comment out the two lines above this #############
-## We currently haven't implemented and tested GPU acceleration on OSX (although it's possible for osx-arm64).
-## This is also the case for linux powerPC and ARM cores.
-## We also don't support it on Windows, because we need magma as a dependency and on windows, CMake isn’t playing ball
-## with building it with CUDA support.
-## So, only linux-64 for now.
-## Additionally, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
+## We currently support GPUs on linux-64 (with a CUDA backend) and osx-arm64 (with an MPS backend)
+## We don't support it on Windows, because we need magma as a dependency and there have been significant issues getting
+## CMake to build magma with CUDA support.
+## For linux-64, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
 ## https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html
-#pytorch_variant:       # [(linux and x86_64)]
-#  - gpu                # [(linux and x86_64)]
+#pytorch_variant:       # [(linux and x86_64) or (osx and arm64)]
+#  - gpu                # [(linux and x86_64) or (osx and arm64)]
 #c_compiler_version:    # [(linux and x86_64)]
 #  - 9                  # [(linux and x86_64)]
 #cxx_compiler_version:  # [(linux and x86_64)]
@@ -35,3 +29,7 @@ CONDA_BUILD_SYSROOT:         # [osx]
 #  - 11.3               # [(linux and x86_64)]
 #cudnn:                 # [(linux and x86_64)]
 #  - 8                  # [(linux and x86_64)]
+#MACOSX_SDK_VERSION:    # [(osx and arm64)]
+#  - 12.3               # [(osx and arm64)]
+#CONDA_BUILD_SYSROOT:   # [(osx and arm64)]
+#  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
+  # This is because this PR is only for GPU on osx-arm64. Will remove after merging
   skip: True  # [not (osx and arm64)]
   # Dropping ppc because of various build issues
   skip: True  # [(linux and ppc64le)]
@@ -191,7 +192,7 @@ test:
     - test/
   commands:
     # We seem to have individual platform-specific test failures or flaky
-    # tests, but the majority of tests passes.
+    # tests, but the majority of tests pass.
     - set CONTINUE_THROUGH_ERROR=1     # [win]
     - export CONTINUE_THROUGH_ERROR=1  # [not win]
     - python ./test/run_test.py --core || true
@@ -205,11 +206,11 @@ test:
     # distributed support is enabled by default on linux; for mac, we enable it manually in build.sh
     - python -c "import torch; assert torch.distributed.is_available()"        # [linux or osx]
     - python -c "import torch; assert torch.backends.mkldnn.m.is_available()"  # [x86 and cuda_compiler_version == "None"]
-    - python -c "import torch; assert torch.backends.cuda.is_built()"          # [pytorch_variant == "gpu"]
-    - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [pytorch_variant == "gpu"]
-    - python -c "import torch; assert torch.cuda.is_available()"               # [pytorch_variant == "gpu"]
-    - python -c "import torch; assert torch.backends.cudnn.enabled"            # [pytorch_variant == "gpu"]
-    - python -c "import torch; assert torch.backends.mps.is_built()"
+    - python -c "import torch; assert torch.backends.cuda.is_built()"          # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - python -c "import torch; assert torch.cuda.is_available()"               # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - python -c "import torch; assert torch.backends.cudnn.enabled"            # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - python -c "import torch; assert torch.backends.mps.is_built()"           # [(pytorch_variant == "gpu") and (osx and arm64)]
 
 about:
   home: https://pytorch.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -209,7 +209,7 @@ test:
     - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [pytorch_variant == "gpu"]
     - python -c "import torch; assert torch.cuda.is_available()"               # [pytorch_variant == "gpu"]
     - python -c "import torch; assert torch.backends.cudnn.enabled"            # [pytorch_variant == "gpu"]
-    - python -c "import torch; assert torch.backends.mps.is_available()"
+    - python -c "import torch; assert torch.backends.mps.is_built()"
 
 about:
   home: https://pytorch.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
+  skip: True  # [not (osx and arm64)]
   # ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
   skip: True  # [(linux and ppc64le) and py==311]
   # TODO: note that at the moment we only use CUDA backend, e.g. would be different for mac
@@ -208,6 +209,7 @@ test:
     - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [pytorch_variant == "gpu"]
     - python -c "import torch; assert torch.cuda.is_available()"               # [pytorch_variant == "gpu"]
     - python -c "import torch; assert torch.backends.cudnn.enabled"            # [pytorch_variant == "gpu"]
+    - python -c "import torch; assert torch.backends.mps.is_available()"
 
 about:
   home: https://pytorch.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,8 @@ build:
   skip: True  # [not (osx and arm64)]
   # Dropping ppc because of various build issues
   skip: True  # [(linux and ppc64le)]
-  # TODO: note that at the moment we only use CUDA backend, e.g. would be different for mac
-  string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
+  string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
+  string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [(pytorch_variant == "gpu") and (osx and arm64)]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]
   detect_binary_files_with_prefix: False
   entry_points:
@@ -76,9 +76,9 @@ build:
     - "**/shm.dll"                # [win]
     - "**/torch_cpu.dll"          # [win]
     - "**/torch_python.dll"       # [win]
-    - "**/libcuda.so*"            # [pytorch_variant == "gpu"]
-    - "**/libtorch_cuda.so"       # [pytorch_variant == "gpu"]
-    - "**/libc10_cuda.so"         # [pytorch_variant == "gpu"]
+    - "**/libcuda.so*"            # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - "**/libtorch_cuda.so"       # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - "**/libc10_cuda.so"         # [(pytorch_variant == "gpu") and (linux and x86_64)]
 
 requirements:
   # WARNING:
@@ -108,15 +108,15 @@ requirements:
     - protobuf                        # [not win]
   host:
     # GPU requirements
-    - cudatoolkit {{ cudatoolkit }}*  # [pytorch_variant == "gpu"]
-    - cudnn {{ cudnn }}*              # [pytorch_variant == "gpu"]
-    - magma 2.7.0                     # [pytorch_variant == "gpu"]
+    - cudatoolkit {{ cudatoolkit }}*  # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - cudnn {{ cudnn }}*              # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - magma 2.7.0                     # [(pytorch_variant == "gpu") and (linux and x86_64)]
     # Required for GPU profiler
-    - cupti 11.3.1                    # [pytorch_variant == "gpu"]
+    - cupti 11.3.1                    # [(pytorch_variant == "gpu") and (linux and x86_64)]
     # OpenBLAS or MKL
     - mkl-devel {{ mkl }}.*           # [blas_impl == "mkl"]
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
-    - openblas {{ openblas }}                 # [blas_impl == "openblas"]
+    - openblas {{ openblas }}         # [blas_impl == "openblas"]
     # OpenMP
     # We pull in the same versions of mkl and intel-openmp: intel aligns the versions
     # We use intel-openmp for all mkl variants.
@@ -125,7 +125,7 @@ requirements:
     # Other requirements
     - cffi 1.15.1
     - future 0.18.2
-    - libprotobuf {{ libprotobuf }}       # [not win]
+    - libprotobuf {{ libprotobuf }}   # [not win]
     # on osx, libuv supports torch.distributed support. See build.sh.
     - libuv 1.44.2                    # [win or osx]
     # Pinnings as per pytorch/.circleci/docker/common/install_conda.sh,
@@ -133,14 +133,14 @@ requirements:
     - numpy 1.23          # [py==311]
     - numpy >=1.21,<1.22  # [py==310]
     - numpy >=1.19,<1.20  # [py<=39]
-    - pip                               # Required for in tree builds
-    - pkg-config 0.29.2                 # [unix]
+    - pip                             # Required for in tree builds
+    - pkg-config 0.29.2               # [unix]
     - python
     - pyyaml 6.0
     - requests 2.28.1
     # CF: PyTorch relies on features that were removed in later versions.
     - setuptools
-    - sleef 3.5.1                       # [osx and arm64]
+    - sleef 3.5.1                     # [osx and arm64]
     - typing-extensions 4.4.0
     - wheel
     - pybind11 2.10.1
@@ -152,10 +152,10 @@ requirements:
     # OpenMP
     - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
     # GPU requirements
-    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
-    - {{ pin_compatible('cudnn') }}                       # [pytorch_variant == "gpu"]
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
+    - {{ pin_compatible('cudnn') }}                       # [(pytorch_variant == "gpu") and (linux and x86_64)]
     # Required for GPU profiler
-    - cupti                           # [pytorch_variant == "gpu"]
+    - cupti                           # [(pytorch_variant == "gpu") and (linux and x86_64)]
     # other requirements
     - cffi
     # CF: pip check may fail if future is not installed
@@ -170,7 +170,7 @@ requirements:
     # To stop the compiler pulling in an openmp implementation itself
     - _openmp_mutex                   # [linux]
     - pyyaml
-    - magma                           # [pytorch_variant == "gpu"]
+    - magma                           # [(pytorch_variant == "gpu") and (linux and x86_64)]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,8 @@ build:
   number: 0
   skip: True  # [py<37]
   skip: True  # [not (osx and arm64)]
-  # ppc requires gcc v8 (see cbc.yaml). Python 3.11 is incompatible with anything built with gcc<11 because of runtime conflicts.
-  skip: True  # [(linux and ppc64le) and py==311]
+  # Dropping ppc because of various build issues
+  skip: True  # [(linux and ppc64le)]
   # TODO: note that at the moment we only use CUDA backend, e.g. would be different for mac
   string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]


### PR DESCRIPTION
## Links

[Upstream](https://github.com/pytorch/pytorch/tree/v1.13.1)
[Instructions on building on mac for GPU](https://developer.apple.com/metal/pytorch/)
[Jira ticket](https://anaconda.atlassian.net/browse/PKG-1242?atlOrigin=eyJpIjoiMGYxOTJlNTQ4MWRkNDVhYzhkZDc2MzVlMjBjNTAwZDUiLCJwIjoiaiJ9)

## Changes

- Use the `USE_MPS` environment variable to turn on GPU backend building
- Use the correct version of MacOS SDK
- Set an environment variable to help the Anaconda CI find the correct SDK (see [this slack comment/thread](https://anaconda.slack.com/archives/C03J3NQPS0Z/p1685646003488849?thread_ts=1683227605.879399&cid=C03J3NQPS0Z)
- Add a test for mps backend being built ('is_available()' will not be `true` on the prefect builders, because the OS needs also to be more recent than 12.3, which isn't the case)
- Drop `ppc` entirely (see [this slack thread](https://anaconda.slack.com/archives/C02K52E033M/p1684936121788699))
- Adapt previous `GPU` selectors to be `GPU` on `linux-64` selectors, because they were specific to `CUDA`, not `GPU` support in general.
