### PR TITLE
V2.0.1 GPU osxarm64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -20,25 +20,25 @@ CONDA_BUILD_SYSROOT:         # [(osx and x86_64)]
 blas_impl:
   - mkl                        # [x86 or x86_64]
   - openblas                   # [not win and not (osx and x86_64)]
-pytorch_variant:
-  - cpu
-# ################ For GPU building, uncomment everything below and comment out the two lines above this #############
-# # We currently support GPUs on linux-64 (with a CUDA backend) and osx-arm64 (with an MPS backend)
-# # We don't support it on Windows, because we need magma as a dependency and there have been significant issues getting
-# # CMake to build magma with CUDA support.
-# # For linux-64, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
-# # https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html
-# pytorch_variant:       # [(linux and x86_64) or (osx and arm64)]
-#  - gpu                # [(linux and x86_64) or (osx and arm64)]
-# c_compiler_version:    # [(linux and x86_64)]
-#  - 9                  # [(linux and x86_64)]
-# cxx_compiler_version:  # [(linux and x86_64)]
-#  - 9                  # [(linux and x86_64)]
-# cudatoolkit:           # [(linux and x86_64)]
-#  - 11.3               # [(linux and x86_64)]
-# cudnn:                 # [(linux and x86_64)]
-#  - 8                  # [(linux and x86_64)]
-# MACOSX_SDK_VERSION:    # [(osx and arm64)]
-#  - 12.3               # [(osx and arm64)]
-# CONDA_BUILD_SYSROOT:   # [(osx and arm64)]
-#  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [(osx and arm64)]
+# pytorch_variant:
+#   - cpu
+################ For GPU building, uncomment everything below and comment out the two lines above this #############
+# We currently support GPUs on linux-64 (with a CUDA backend) and osx-arm64 (with an MPS backend)
+# We don't support it on Windows, because we need magma as a dependency and there have been significant issues getting
+# CMake to build magma with CUDA support.
+# For linux-64, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
+# https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html
+pytorch_variant:       # [(linux and x86_64) or (osx and arm64)]
+ - gpu                # [(linux and x86_64) or (osx and arm64)]
+c_compiler_version:    # [(linux and x86_64)]
+ - 9                  # [(linux and x86_64)]
+cxx_compiler_version:  # [(linux and x86_64)]
+ - 9                  # [(linux and x86_64)]
+cudatoolkit:           # [(linux and x86_64)]
+ - 11.3               # [(linux and x86_64)]
+cudnn:                 # [(linux and x86_64)]
+ - 8                  # [(linux and x86_64)]
+MACOSX_SDK_VERSION:    # [(osx and arm64)]
+ - 12.3               # [(osx and arm64)]
+CONDA_BUILD_SYSROOT:   # [(osx and arm64)]
+ - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [(osx and arm64)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,13 +15,13 @@ MACOSX_SDK_VERSION:          # [(osx and x86_64)]
   - 10.15                    # [(osx and x86_64)]
 CONDA_BUILD_SYSROOT:         # [(osx and x86_64)]
   - /opt/MacOSX10.15.sdk     # [(osx and x86_64)]
-pytorch_variant:
-  - cpu
 # openblas/osx-64 isn't currently building, but is under investigation and to be fixed in a later build.
 # blas_impl is the same as in aggregate cbc.yaml otherwise.
 blas_impl:
   - mkl                        # [x86 or x86_64]
   - openblas                   # [not win and not (osx and x86_64)]
+pytorch_variant:
+  - cpu
 # ################ For GPU building, uncomment everything below and comment out the two lines above this #############
 # # We currently support GPUs on linux-64 (with a CUDA backend) and osx-arm64 (with an MPS backend)
 # # We don't support it on Windows, because we need magma as a dependency and there have been significant issues getting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
   skip: True  # [py<38]
   # Dropping ppc because of various build issues
   skip: True  # [(linux and ppc64le)]
+  # Only building for osx-arm64 GPU in this PR
+  skip: True  # [(osx and arm64)]
   string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
   string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [(pytorch_variant == "gpu") and (osx and arm64)]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
   # Dropping ppc because of various build issues
   skip: True  # [(linux and ppc64le)]
   # Only building for osx-arm64 GPU in this PR
-  skip: True  # [(osx and arm64)]
+  skip: True  # [not (osx and arm64)]
   string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
   string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [(pytorch_variant == "gpu") and (osx and arm64)]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]


### PR DESCRIPTION
Simple PR which turns on GPU building and restricts the build to only osx-arm64.

linux-64 GPU variant still in progress.