### PR TITLE
osx-arm64 GPU metapackage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ outputs:
   # GPU variant if their platform supports it and the CPU variant otherwise.
   - name: pytorch-{{ pytorch_variant }}
     build:
-      noarch: generic
       skip: True  # [py<38]
     requirements:
       run:
@@ -56,6 +55,10 @@ outputs:
     script: bld_pytorch.bat  # [win]
     build:
       skip: True  # [py<38]
+      # The last PR/upload was for the pytorch-gpu metapackage
+      # for osx-arm64 only.
+      # If you're seeing this line, delete it.
+      skip: True
       string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
       string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [(pytorch_variant == "gpu") and (osx and arm64)]
       string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]


### PR DESCRIPTION
Make metapackage arch specific; only build metapackage

- having the metapackages as noarch for gpu means that there's a pytorch-gpu package for archs where there's no gpu variant, which is misleading. So we make it arch-specific
- we also want to only build this metapackage for this PR, so skip: True has been added for the main package.

Note that the pytorch-cpu metapackage is currently noarch whereas in the future it will be arch-specific. This shouldn't be a problem

I'll follow up this PR with another one removing the `skip: True` statements I've been using, and I also opened a [jira ticket](https://anaconda.atlassian.net/browse/PKG-3426) to find a better way to do this