### PR TITLE
update to 2.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,14 +1,5 @@
-# This suppresses erroneous overdepending errors;
-# there are packages needed to be loaded during runtime
-# which conda thinks aren't required
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--skip-existing"
-
 # macOS 12.3 or above is required for running the GPU variant (MPS support). No way to specify this for only the GPU
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
 
-aggregate_branch: 3.12

--- a/recipe/README
+++ b/recipe/README
@@ -12,7 +12,7 @@ is the entry point to the Pytorch build system.
 # GPU building
 
 To build with GPU support, uncomment/comment the lines in conda_build_config.yaml as documented there. Currently, these
-builds need to be done manually on a machine with cudatoolkit installed, as the CI system does not support them.
+builds need to be done manually on a machine with the linux drivers installed, as the CI system does not support them.
 
 # Tests
 
@@ -20,6 +20,17 @@ Note that the PyTorch test suite is run, but there is no indication of test resu
 fallen over completely, without looking at the logs. It is very important to validate the package by looking at the test
 results before release. A statistically small number of test failures is generally ok, for example because of floating
 point hardware implementation differences on different architectures.
+
+# Handling long builds
+
+The builds are very long, but there are some measures you can take to reduce them during development.
+
+1. Only build one python variant. Currently the most supported variant is python 3.11; python 3.12 isn't supported for
+   some features.
+2. Use ccache. Note that ccache will result in cache misses if the build folder is different, which is the case by
+   default if conda-build is called twice. To get around this, build in a previous folder (conda build --dirty <previous_root_folder_name>)
+   or export CCACHE_BASEDIR=${PREFIX}/../  to strip the root folder (untested, needs to be there before the first run).
+3. (For CUDA) only build the compute capability of the build/test machine. (TORCH_CUDA_ARCH_LIST)
 
 # Further work
 

--- a/recipe/bld_pytorch.bat
+++ b/recipe/bld_pytorch.bat
@@ -55,9 +55,11 @@ set USE_TENSORPIPE=0
 set DISTUTILS_USE_SDK=1
 set BUILD_TEST=0
 :: Don't increase MAX_JOBS to NUMBER_OF_PROCESSORS, as it will run out of heap
-set CPU_COUNT=2
+set CPU_COUNT=1
 set MAX_JOBS=%CPU_COUNT%
 :: Use our Pybind11, Eigen
+:: Note that BUILD_CUSTOM_PROTOBUF=OFF doesn't work properly as of last testing, and results in
+:: duplicate symbols at link time.
 set USE_SYSTEM_PYBIND11=1
 set USE_SYSTEM_EIGEN_INSTALL=1
 
@@ -79,10 +81,5 @@ set BLAS=MKL
 :: Tell Pytorch's embedded FindMKL where to find MKL.
 set INTEL_MKL_DIR=%LIBRARY_PREFIX%
 
-%PYTHON% -m pip install . ^
-    --no-deps ^
-    --no-binary :all: ^
-    --no-clean ^
-    --no-build-isolation ^
-    -v
+%PYTHON% -m pip install . --no-deps --no-build-isolation -v
 if errorlevel 1 exit /b 1

--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -190,14 +190,10 @@ esac
 
 
 
-# The build needs a lot of memory. Limit to 4 CPUs to take it easy on builders.
-export MAX_JOBS=$((${CPU_COUNT} > 4 ? 4 : ${CPU_COUNT}))
+# Leave a spare core for other tasks. This may need to be reduced further
+# if we get out of memory errors. (Each job uses a certain amount of memory.)
+export MAX_JOBS=$((CPU_COUNT > 1 ? CPU_COUNT - 1 : 1))
 
 # The Pytorch build system is invoked
 # via their setup.py
-"$PYTHON" -m pip install . \
-    --no-deps \
-    --no-binary :all: \
-    --no-clean \
-    --no-build-isolation \
-    -v
+"$PYTHON" -m pip install . --no-deps --no-build-isolation -v

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,11 +12,6 @@ MACOSX_DEPLOYMENT_TARGET:    # [(osx and x86_64)]
   - 10.15                    # [(osx and x86_64)]
 CONDA_BUILD_SYSROOT:         # [(osx and x86_64)]
   - /opt/MacOSX10.15.sdk     # [(osx and x86_64)]
-# openblas/osx-64 isn't currently building, but is under investigation and to be fixed in a later build.
-# blas_impl is the same as in aggregate cbc.yaml otherwise.
-blas_impl:
-  - mkl                      # [x86 or x86_64]
-  - openblas                 # [not win and not (osx and x86_64)]
 pytorch_variant:
   - cpu
   - gpu                      # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "2.2.0" %}
+{% set version = "2.3.0" %}
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
-{% set sha256 = "e12d18c3dbb12d7ae2f61f5ab9a21023e3dd179d67ed87279ef96600b9ac08c5" %}
+{% set sha256 = "69579513b26261bbab32e13b7efc99ad287fcf3103087f2d4fdf1adacd25316f" %}
 {% set build_number = 0 %}
 
 package:
@@ -21,6 +21,7 @@ source:
     - patches/0001-windows-FindMKL-add-library-suffix.patch  # [win]
     - patches/0002-swap-openmp-search-precedence.patch      # [blas_impl == "mkl"]
     - patches/0003-continue-tests-on-failure.patch
+    - patches/0004-remove-mkl-constraint-win.patch           # [win]
 
 build:
   # Use a build number difference to ensure that the GPU
@@ -29,22 +30,22 @@ build:
   number: {{ build_number + 100 }}  # [pytorch_variant == "gpu"]
   number: {{ build_number }}        # [pytorch_variant == "cpu"]
   skip: True  # [py<38]
-  # Dropping ppc because of various build issues
-  skip: True  # [(linux and ppc64le)]
+  skip: True  # [osx and (blas_impl == "mkl")]
 
-{% if rc %}
 requirements:
   build:
-    - git                             # [unix] 
+    - python
+{% if rc %}
+    - git  # [unix]
 {% endif %}
+  host:
+    - python
 
 outputs:
   # The pytorch-cpu and pytorch-gpu metapackages are packages which the user can use to get the
   # corresponding pytorch variant. If they install the pytorch package, it will give them the
   # GPU variant if their platform supports it and the CPU variant otherwise.
   - name: pytorch-{{ pytorch_variant }}
-    build:
-      skip: True  # [py<38]
     requirements:
       run:
         - pytorch ={{ version }}={{ pytorch_variant }}* # NB pinning exact=True will also pin to the python version
@@ -53,11 +54,9 @@ outputs:
     script: build_pytorch.sh # [not win]
     script: bld_pytorch.bat  # [win]
     build:
-      skip: True  # [py<38]
       string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
       string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [(pytorch_variant == "gpu") and (osx and arm64)]
       string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]
-      detect_binary_files_with_prefix: False
       entry_points:
         - torchrun = torch.distributed.run:main
       missing_dso_whitelist:
@@ -77,6 +76,7 @@ outputs:
         - "**/libtorch_cpu.dylib"     # [osx]
         - "**/libtorch_python.dylib"  # [osx]
         - "**/libiomp5.dylib"         # [osx]
+        - "**/libomp.dylib"           # [osx]
         - "**/libc++.1.dylib"         # [osx]
         # conda-build also can't find these on Windows sometimes, for example Python 3.8, in Powershell with cygwin added to
         # the PATH. Error message is "$RPATH/<libname>.dll not found". Maybe RPATH isn't being defined correctly?
@@ -90,27 +90,20 @@ outputs:
         - "**/libcuda.so*"            # [(pytorch_variant == "gpu") and (linux and x86_64)]
         - "**/libtorch_cuda.so"       # [(pytorch_variant == "gpu") and (linux and x86_64)]
         - "**/libc10_cuda.so"         # [(pytorch_variant == "gpu") and (linux and x86_64)]
-
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake
-        - make                            # [unix]
         - git                             # [unix]
         - patch                           # [not win]
         - m2-patch                        # [win]
-        - python ={{PY_VER}}
+        - python
         - ninja-base
+        - pkg-config                      # [unix]
         # This has a strong run_export so we don't need to put it in `host` or `run`
         # We use llvm-openmp for openblas variants on osx.
-        - llvm-openmp                     # [osx and not (blas_impl == "mkl")]
-        # Keep libprotobuf here so that a compatibile version
-        # of protobuf is installed between build and host
-        # Unvendoring protobuf doesn't work properly for windows
-        # (due to errors in the Pytorch build system)
-        - libprotobuf                     # [not win]
-        - protobuf                        # [not win]
+        - llvm-openmp 14.0.6              # [osx and not (blas_impl == "mkl")]
       host:
         # GPU requirements
         - cudatoolkit {{ cudatoolkit }}*  # [(pytorch_variant == "gpu") and (linux and x86_64)]
@@ -120,47 +113,40 @@ outputs:
         - cupti 11.8.0                    # [(pytorch_variant == "gpu") and (linux and x86_64)]
         # OpenBLAS or MKL
         - mkl-devel {{ mkl }}.*           # [blas_impl == "mkl"]
-        - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
-        - openblas {{ openblas }}         # [blas_impl == "openblas"]
+        - openblas-devel {{ openblas }}   # [blas_impl == "openblas"]
         # OpenMP
         # We pull in the same versions of mkl and intel-openmp: intel aligns the versions
         # We use intel-openmp for all mkl variants.
         # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
         - intel-openmp   {{ mkl }}        # [blas_impl == "mkl"]
+        - llvm-openmp 14.0.6              # [osx and not (blas_impl == "mkl")]
         # Other requirements
-        - cffi 1.15.1
         - libprotobuf {{ libprotobuf }}   # [not win]
         # on osx, libuv supports torch.distributed support. See build.sh.
         - libuv 1.44.2                    # [win or osx]
         - numpy {{ numpy }}
         - pip                             # Required for in tree builds
-        - pkg-config 0.29.2               # [unix]
         - python
-        - pyyaml 6.0.1
-        - requests 2.31.0
-        # CF: PyTorch relies on features that were removed in later versions.
+        - pyyaml
+        - requests
         - setuptools
         - sleef 3.5.1                     # [osx and arm64]
-        - typing_extensions
+        - typing_extensions >=4.8.0
         - wheel
-        - pybind11 2.10.4
+        - pybind11 2.12.0
         - eigen 3.3.7
         - astunparse 1.6.3
       run:
-        # OpenBLAS or MKL
-        - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
-        - libopenblas                     # [blas_impl == "openblas"]
         # OpenMP
         - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
+        - llvm-openmp                            # [osx and not (blas_impl == "mkl")]
         # GPU requirements
         - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
         - {{ pin_compatible('cudnn') }}                       # [(pytorch_variant == "gpu") and (linux and x86_64)]
         # Required for GPU profiler
         - cupti                           # [(pytorch_variant == "gpu") and (linux and x86_64)]
         # other requirements
-        - cffi
         # CF: needed to load C++ extensions
-        - ninja
         - {{ pin_compatible('numpy') }}
         - python
         - typing_extensions >=4.8.0
@@ -171,11 +157,14 @@ outputs:
         - jinja2
         - networkx
         - sympy
-        - fsspec 
+        - fsspec
         - __cuda >={{ cudatoolkit }}      # [(pytorch_variant == "gpu") and (linux and x86_64)]
         # On macOS, the GPU accelerated backend, MPS, can be used from macOS v12.3. This isn't tightly dependent on the
         # SDK version used.
         - __osx >=12.3                    # [(pytorch_variant == "gpu") and (osx and arm64)]
+      run_constrained:
+        # current intel-openmp builds are incompatible with llvm-openmp on osx-64
+        - llvm-openmp <0a0                # [(blas_impl == "mkl") and (osx and x86_64)]  
 
     test:
       requires:
@@ -193,7 +182,6 @@ outputs:
         - tabulate
         - boto3
         - pytest-rerunfailures
-        - pytest-shard
         - pytest-flakefinder
         - pytest-xdist
       imports:
@@ -222,7 +210,9 @@ outputs:
         - export MATRIX_CHANNEL="defaults"                                            # [not win]
         - export MATRIX_STABLE_VERSION="{{ version }}"                                # [not win]
         - export MATRIX_PACKAGE_TYPE="conda"                                          # [not win]
-        - export TARGET_OS="unix"                                                     # [not win]
+        - export TARGET_OS="linux"                                                    # [linux]
+        - export TARGET_OS="macos-arm64"                                              # [(osx and arm64)]
+        - export TARGET_OS="macos-x86_64"                                             # [(osx and x86_64)]
         - python ./smoke_test.py --package torchonly
         # We seem to have individual platform-specific test failures or flaky
         # tests, but the majority of tests pass.
@@ -263,6 +253,8 @@ about:
   doc_url: https://pytorch.org/docs/
 
 extra:
+  skip-lints:
+    - missing_tests
   recipe-maintainers:
     - tobijk
     - danpetry

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,8 @@ outputs:
       string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]
       entry_points:
         - torchrun = torch.distributed.run:main
+      ignore_run_exports:             # [osx]
+        - libuv                       # [osx]
       missing_dso_whitelist:
         # For some reason, the .sos built for python 3.11 look for .sos for linking in directories of a different
         # python. This patches over this, although it's not great and the problem should be fixed properly.

--- a/recipe/patches/0001-windows-FindMKL-add-library-suffix.patch
+++ b/recipe/patches/0001-windows-FindMKL-add-library-suffix.patch
@@ -8,9 +8,21 @@ This is required because our mdl-devel package contains libraries named like
 
 Index: pytorch/cmake/Modules/FindMKL.cmake
 ===================================================================
---- pytorch.orig/cmake/Modules/FindMKL.cmake	2023-11-14 14:57:21.419923293 -0600
-+++ pytorch/cmake/Modules/FindMKL.cmake	2023-11-14 14:59:15.129813164 -0600
-@@ -255,7 +255,7 @@
+diff --git a/cmake/Modules/FindMKL.cmake b/cmake/Modules/FindMKL.cmake
+index a02f3e092d1..62c006e4ae2 100644
+--- a/cmake/Modules/FindMKL.cmake
++++ b/cmake/Modules/FindMKL.cmake
+@@ -104,6 +104,9 @@ ELSE(CMAKE_COMPILER_IS_GNUCC)
+   ELSE()
+     SET(mklthreads "mkl_intel_thread")
+     SET(mklrtls "iomp5" "guide")
++    IF (MSVC)
++      SET(mklrtls "libiomp5md")
++    ENDIF (MSVC)
+   ENDIF()
+   SET(mklifaces  "intel")
+ ENDIF (CMAKE_COMPILER_IS_GNUCC)
+@@ -252,7 +255,7 @@ MACRO(CHECK_ALL_LIBRARIES LIBRARIES OPENMP_TYPE OPENMP_LIBRARY _name _list _flag
            ENDIF(OPENMP_FOUND)
          ELSEIF(${_library} MATCHES "iomp")
            SET(_openmp_type "Intel")
@@ -19,16 +31,7 @@ Index: pytorch/cmake/Modules/FindMKL.cmake
            SET(_openmp_library "${${_prefix}_${_library}_LIBRARY}")
          ELSE()
            MESSAGE(FATAL_ERROR "Unknown OpenMP flavor: ${_library}")
-@@ -264,7 +264,7 @@
-         # Separately handling compiled TBB
-         SET(_found_tbb TRUE)
-       ELSE()
--        SET(lib_names ${_library})
-+        SET(lib_names ${_library}_dll)
-         FIND_LIBRARY(${_prefix}_${_library}_LIBRARY NAMES ${lib_names})
-       ENDIF()
-       MARK_AS_ADVANCED(${_prefix}_${_library}_LIBRARY)
-@@ -397,19 +397,19 @@
+@@ -402,23 +405,23 @@ IF (MKL_LIBRARIES)
    FOREACH(mkl64 ${mkl64s} "_core" "")
      FOREACH(mkls ${mklseq} "")
        IF (NOT MKL_LAPACK_LIBRARIES)

--- a/recipe/patches/0003-continue-tests-on-failure.patch
+++ b/recipe/patches/0003-continue-tests-on-failure.patch
@@ -1,8 +1,8 @@
 Index: pytorch/test/run_test.py
 ===================================================================
---- pytorch.orig/test/run_test.py	2024-01-23 14:39:11.833933440 -0600
-+++ pytorch/test/run_test.py	2024-01-30 15:12:05.219026815 -0600
-@@ -1053,7 +1053,7 @@
+--- pytorch.orig/test/run_test.py	2024-05-28 15:39:11.509937490 -0500
++++ pytorch/test/run_test.py	2024-05-28 15:39:21.157211301 -0500
+@@ -976,7 +976,7 @@
      else:
          # When under the normal mode, retry a failed test 2 more times. -x means stop at the first
          # failure

--- a/recipe/patches/0004-remove-mkl-constraint-win.patch
+++ b/recipe/patches/0004-remove-mkl-constraint-win.patch
@@ -1,0 +1,15 @@
+This is to stop pip check complaining.
+
+mkl isn't a python package for us so there's no metadata to support pip check.
+Index: pytorch/setup.py
+===================================================================
+--- pytorch.orig/setup.py	2024-05-03 14:37:02.824162543 -0500
++++ pytorch/setup.py	2024-05-29 11:37:14.428877813 -0500
+@@ -1111,7 +1111,6 @@
+         "networkx",
+         "jinja2",
+         "fsspec",
+-        'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows"',
+     ]
+ 
+     # Parse the command line and check the arguments before we proceed with


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4294](https://anaconda.atlassian.net/browse/PKG-4294) 
- [Upstream repository](https://github.com/pytorch/pytorch/tree/v2.3.0)
- [Upstream changelog/diff](https://github.com/pytorch/pytorch/releases/tag/v2.3.0)

### Explanation of changes:

If a review is possible contingent on build succeeding, that would be helpful, due to long build times

- remove unneeded abs.yaml lines (overdepending check not done in CI anyway)
- remove unneeded python 3.12 aggregate branch (python 3.12 now built on main agg branch)
- include text about handling long builds
- reduce MAX_JOBS on windows to 1, as it tends to run out of heap on our CI otherwise
- add note about removing protobuf not working correctly on Windows
- tidy pip install lines
- explicitly specify Ninja as build system and remove make
- increase MAX_JOBS on linux to leave only one core free
- remove the blas configuration and skip osx mkl in the recipe instead, for clarity
- increase version, set sha
- remove mkl entry in setup.py as it gives a false positive when running pip check on windows
- remove ppc skip, we don't build ppc at all anymore
- debug global requirements for rc configuration
- replace prefixes in binaries upon installation; reason why this was false is lost in time, but it should probably be true
- add libomp.dylib to whitelist for same reason as others
- sort out issues with BLAS/OpenMP by specifying different packages that enforce mutual exclusion
- Remove unneeded deps: protobuf in build and cffi in host
- Put pkg-config in build rather than host, as it's a build tool
- un-pin python deps
- update dep pinnings to match with upstream and sort out conflicts
- update smoke_test.py to latest; update env variables in line
- remove pytest-shard as pytorch includes their own patched version now
- update patches


[PKG-4294]: https://anaconda.atlassian.net/browse/PKG-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ