### PR TITLE
PKG-3612 V2.3.0 cuda 118 skip CI

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,3 @@
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
-

--- a/recipe/README
+++ b/recipe/README
@@ -32,6 +32,11 @@ The builds are very long, but there are some measures you can take to reduce the
    or export CCACHE_BASEDIR=${PREFIX}/../  to strip the root folder (untested, needs to be there before the first run).
 3. (For CUDA) only build the compute capability of the build/test machine. (TORCH_CUDA_ARCH_LIST)
 
+Additionally, once review is done, you can merge without rebuilding (by adding "skip CI" to the PR title) and then take
+the packages from the staging channel. Note that in this case, you need to
+[manually sign](https://github.com/anaconda-distribution/perseverance-skills/blob/3c36b68a1b2068823074fdec317e9928300d715e/sections/02_Package_building/01_How_tos/Manually_building_release_packages.md?plain=1#L19)
+the windows packages.
+
 # Further work
 
 ## Unvendoring

--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -39,6 +39,11 @@ export Python3_EXECUTABLE="${PYTHON}"
 
 export CMAKE_GENERATOR=Ninja
 
+# Uncomment to use ccache; development only
+# export CMAKE_C_COMPILER_LAUNCHER=ccache
+# export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+# export CMAKE_CUDA_COMPILER_LAUNCHER=ccache
+# export CCACHE_BASEDIR=${PREFIX}/../
 
 #################### ADJUST COMPILER AND LINKER FLAGS #####################
 # Pytorch's build system doesn't like us setting the c++ standard and will
@@ -104,73 +109,79 @@ export PYTORCH_BUILD_NUMBER=$PKG_BUILDNUM
 # CUDA is used as the acceleration backend
 # for GPU builds; MKL or openBLAS is used as
 # the backend for CPU builds.
-if [[ ${pytorch_variant} = "gpu" ]]; then
+if [[ ${gpu_variant} == "metal" ]]; then
 
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    ###### Mac - MPS backend ######
+    export USE_MPS=1
 
-        ###### Mac - MPS backend ######
-        export USE_MPS=1
+elif [[ ${gpu_variant} == "cuda-11" ]]; then
 
+    export USE_CUDA=1
+
+    # Warning from pytorch v1.12.1: In the future we will require one to
+    # explicitly pass TORCH_CUDA_ARCH_LIST to cmake instead of implicitly
+    # setting it as an env variable.
+
+    # This is valid for each cudatoolkit version but was applied here only
+    # from cudatoolkit >= 11.8, as we won't rebuild older versions:
+    #
+    # +PTX should go to the oldest arch. There's a modest runtime performance
+    # hit for (unlisted) newer arches on doing this, but that must be set
+    # when wide compatibility is a concern.
+    #
+    # https://pytorch.org/docs/stable/cpp_extension.html (Compute capabilities)
+    # https://github.com/pytorch/builder/blob/c85da84005b44041b75e1eb3221ea7dcbd1b28aa/conda/pytorch-nightly/build.sh#L53-L89
+    if [[ ${cudatoolkit} == 9.0* ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;7.0"
+    elif [[ ${cudatoolkit} == 9.2* ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0"
+    elif [[ ${cudatoolkit} == 10.* ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5"
+    elif [[ ${cudatoolkit} == 11.0* ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0"
+    elif [[ ${cudatoolkit} == 11.1 ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
+    elif [[ ${cudatoolkit} == 11.2 ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
+    elif [[ ${cudatoolkit} == 11.3 ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
+    elif [[ ${cudatoolkit} == 11.8 ]]; then
+        export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
     else
-
-        ###### Linux - CUDA backend ######
-        export USE_CUDA=1
-
-        # Warning from pytorch v1.12.1: In the future we will require one to
-        # explicitly pass TORCH_CUDA_ARCH_LIST to cmake instead of implicitly
-        # setting it as an env variable.
-
-        # This is valid for each cudatoolkit version but was applied here only
-        # from cudatoolkit >= 11.8, as we won't rebuild older versions:
-        #
-        # +PTX should go to the oldest arch. There's a modest runtime performance
-        # hit for (unlisted) newer arches on doing this, but that must be set
-        # when wide compatibility is a concern.
-        #
-        # https://pytorch.org/docs/stable/cpp_extension.html (Compute capabilities)
-        # https://github.com/pytorch/builder/blob/c85da84005b44041b75e1eb3221ea7dcbd1b28aa/conda/pytorch-nightly/build.sh#L53-L89
-        if [[ ${cudatoolkit} == 9.0* ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;7.0"
-        elif [[ ${cudatoolkit} == 9.2* ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0"
-        elif [[ ${cudatoolkit} == 10.* ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5"
-        elif [[ ${cudatoolkit} == 11.0* ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0"
-        elif [[ ${cudatoolkit} == 11.1 ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
-        elif [[ ${cudatoolkit} == 11.2 ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
-        elif [[ ${cudatoolkit} == 11.3 ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
-        elif [[ ${cudatoolkit} == 11.8 ]]; then
-            export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
-        else
-            echo "No CUDA architecture list exists for cuda_compiler_version==${cudatoolkit}"
-            echo "in build.sh. Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one."
-            exit 1
-        fi
-
-        export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
-        export NCCL_ROOT_DIR=/usr/local/cuda
-        export USE_STATIC_NCCL=1
-        export CUDACXX=/usr/local/cuda/bin/nvcc
-        export CUDAHOSTCXX="${CXX}"                # If this isn't included, CUDA will use the system compiler to compile host
-                                                # files, rather than the one in the conda environment, resulting in compiler errors
-        export MAGMA_HOME="${PREFIX}"
-
-        export USE_STATIC_CUDNN=0   # Use our cudnn package
-
+        echo "No CUDA architecture list exists for cudatoolkit==${cudatoolkit}"
+        echo "in build.sh. Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one."
+        exit 1
     fi
 
-else
+    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+    export NCCL_ROOT_DIR=/usr/local/cuda
+    export USE_STATIC_NCCL=1
+    export CUDACXX=/usr/local/cuda/bin/nvcc
+    export CUDAHOSTCXX="${CXX}"                # If this isn't included, CUDA will use the system compiler to compile host
+                                            # files, rather than the one in the conda environment, resulting in compiler errors
+    export MAGMA_HOME="${PREFIX}"
+
+    export USE_STATIC_CUDNN=0   # Use our cudnn package
+
+elif [[ ${gpu_variant} == "cuda-12" ]]; then
+
+    export USE_CUDA=1
+    export TORCH_CUDA_ARCH_LIST="5.0+PTX;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
+    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+    export MAGMA_HOME="${PREFIX}"
+    export USE_STATIC_CUDNN=0   # Use our cudnn package
+    export CUDA_INC_PATH="${PREFIX}/targets/x86_64-linux/include/"  # Point cmake to the header files
+
+elif [[ ${gpu_variant} == "cpu" ]]; then
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
         export USE_MPS=0
     else
         export USE_CUDA=0
     fi
-
+else
+    echo "Unsupported GPU variant: ${gpu_variant}"
+    exit 1
 fi
 
 case "${blas_impl}" in

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,10 @@
+# Comment/uncomment these as necessary. cuda-11/cuda-12 matrix build is untested.
+# CI currently does not handle CUDA; leave cuda variants commented for CI builds.
+gpu_variant:
+  - cpu
+  - metal                    # [(osx and arm64)]
+  #- cuda-11                  # [(linux and x86_64)]
+  #- cuda-12                  # [(linux and x86_64)]
 # If we don't pin the compiler on windows, we get compiler syntax errors. This could be because conda-build pulls in a
 # different runtime version from the compiler version, for some reason. Upstream uses 2019 on their CI, and it's our
 # most recent, so let's use that.
@@ -12,9 +19,6 @@ MACOSX_DEPLOYMENT_TARGET:    # [(osx and x86_64)]
   - 10.15                    # [(osx and x86_64)]
 CONDA_BUILD_SYSROOT:         # [(osx and x86_64)]
   - /opt/MacOSX10.15.sdk     # [(osx and x86_64)]
-pytorch_variant:
-  - cpu
-  - gpu                      # [(osx and arm64)]
 # CONDA_BUILD_SYSROOT is defined in the base cbc.yaml, but it's reflected here so we can zip the keys and
 # build GPU and CPU at the same time for osx-arm64. It'll need to be manually updated here if the base cbc is changed.
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.
@@ -26,22 +30,14 @@ CONDA_BUILD_SYSROOT:         # [(osx and arm64)]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [(osx and arm64)]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk  # [(osx and arm64)]
 zip_keys:                    # [(osx and arm64)]
-  - pytorch_variant          # [(osx and arm64)]
+  - gpu_variant              # [(osx and arm64)]
   - MACOSX_SDK_VERSION       # [(osx and arm64)]
   - CONDA_BUILD_SYSROOT      # [(osx and arm64)]
-
-# Below are the settings for linux-64 GPU. Currently, we're not building it, because we're waiting on
-# Triton to be packaged and included in defaults.
-# These are kept here for reference, when Triton is available.
-# For linux-64, we need to pin the compiler if we're building with CUDA support (but not otherwise), see here:
-# https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html
-# We also don't build it yet on Windows, because we need magma as a dependency and there have been significant issues getting
-# CMake to build magma with CUDA support.
-# c_compiler_version:    # [(linux and x86_64)]
-#  - 11                 # [(linux and x86_64)]
-# cxx_compiler_version:  # [(linux and x86_64)]
-#  - 11                 # [(linux and x86_64)]
-# cudatoolkit:           # [(linux and x86_64)]
-#  - 11.8               # [(linux and x86_64)]
-# cudnn:                 # [(linux and x86_64)]
-#  - 8.9.2.26           # [(linux and x86_64)]
+# gcc/CUDA compatibility guide, for pinning if necessary:
+# https://docs.nvidia.com/cuda/archive/11.8.0/cuda-installation-guide-linux/index.html
+# We don't build a CUDA variant yet for Windows, due to issues getting CMake to build magma with CUDA support.
+# This is only used for cuda-11 gpu variant. Note that commenting out will break recipe rendering, though.
+cudatoolkit:                 # [(linux and x86_64)]
+ - 11.8                      # [(linux and x86_64)]
+cudnn:                       # [(linux and x86_64)]
+ - 8.9.2.26                  # [(linux and x86_64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ outputs:
   - name: pytorch
     script: build_pytorch.sh # [not win]
     script: bld_pytorch.bat  # [win]
+    build:
       string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}            # [gpu_variant == "cuda-11"]
       string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda-12"]
       string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ source:
     - patches/0002-swap-openmp-search-precedence.patch      # [blas_impl == "mkl"]
     - patches/0003-continue-tests-on-failure.patch
     - patches/0004-remove-mkl-constraint-win.patch           # [win]
+    - patches/0005-fix-triton-hash-with-backend.patch
 
 build:
   # Use a build number difference to ensure that the GPU
@@ -67,6 +68,7 @@ outputs:
         # For some reason, the .sos built for python 3.11 look for .sos for linking in directories of a different
         # python. This patches over this, although it's not great and the problem should be fixed properly.
         # Note that this issue is sporadic - you may remove this, and the build may work but then break at a later date.
+        # These are present in the site-packages directory
         - "**/ld64.so.*"              # [linux]
         - "**/libc10.so"              # [linux]
         - "**/libshm.so"              # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,16 +27,17 @@ build:
   # Use a build number difference to ensure that the GPU
   # variant is slightly preferred by conda's solver, so that it's preferentially
   # installed where the platform supports it.
-  number: {{ build_number + 100 }}  # [pytorch_variant == "gpu"]
-  number: {{ build_number }}        # [pytorch_variant == "cpu"]
+  number: {{ build_number + 100 }}  # [gpu_variant != "cpu"]
+  number: {{ build_number }}        # [gpu_variant == "cpu"]
   skip: True  # [py<38]
-  skip: True  # [osx and (blas_impl == "mkl")]
+  # torch.compile isn't supported with python 3.12:
+  # https://github.com/pytorch/pytorch/blob/97ff6cfd9c86c5c09d7ce775ab64ec5c99230f5d/test/test_transformers.py#L3418
+  skip: True  # [py==312 and (gpu_variant or "").startswith("cuda")]
 
+{% if rc %}
 requirements:
   build:
-    - python
-{% if rc %}
-    - git  # [unix]
+    - git                             # [unix]
 {% endif %}
   host:
     - python
@@ -45,18 +46,18 @@ outputs:
   # The pytorch-cpu and pytorch-gpu metapackages are packages which the user can use to get the
   # corresponding pytorch variant. If they install the pytorch package, it will give them the
   # GPU variant if their platform supports it and the CPU variant otherwise.
-  - name: pytorch-{{ pytorch_variant }}
+  - name: pytorch-{{ "cpu" if gpu_variant == "cpu" else "gpu" }}
     requirements:
       run:
-        - pytorch ={{ version }}={{ pytorch_variant }}* # NB pinning exact=True will also pin to the python version
+        - pytorch ={{ version }}={{ "cpu" if gpu_variant == "cpu" else "gpu" }}* # NB pinning exact=True will also pin to the python version
 
   - name: pytorch
     script: build_pytorch.sh # [not win]
     script: bld_pytorch.bat  # [win]
-    build:
-      string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
-      string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [(pytorch_variant == "gpu") and (osx and arm64)]
-      string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                          # [pytorch_variant == "cpu"]
+      string: gpu_cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}            # [gpu_variant == "cuda-11"]
+      string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda-12"]
+      string: gpu_mps_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "metal"]
+      string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                    # [gpu_variant == "cpu"]
       entry_points:
         - torchrun = torch.distributed.run:main
       ignore_run_exports:             # [osx]
@@ -88,15 +89,27 @@ outputs:
         - "**/shm.dll"                # [win]
         - "**/torch_cpu.dll"          # [win]
         - "**/torch_python.dll"       # [win]
-        # CUDA shared libraries are provided by cudatoolkit, i.e. outside the conda build environment
-        - "**/libcuda.so*"            # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - "**/libtorch_cuda.so"       # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - "**/libc10_cuda.so"         # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        # libcuda.so is the cuda driver API library and is a system library.
+        - "**/libcuda.so*"            # [(gpu_variant or "").startswith("cuda")]
+        # these aren't found sometimes, maybe for the same reason as at the top of this section
+        - "**/libtorch_cuda.so"       # [(gpu_variant or "").startswith("cuda")]
+        - "**/libc10_cuda.so"         # [(gpu_variant or "").startswith("cuda")]
+
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ compiler('cuda') }}          # [gpu_variant == "cuda-12"]
+        # The cuda compiler function above pulls in a number of other libraries, leading CMake to find CUDAToolkit in the
+        # build environment. See https://github.com/Kitware/CMake/blob/master/Modules/Internal/CMakeCUDAFindToolkit.cmake#L135
+        # If these two libraries aren't in the build environment they aren't found by PyTorch's build system as a result.
+        # Currently cuda libraries variously from the build and host environments are used by the build system (see logs).
+        # If this turns out to be a problem, we can address it.
+        - libcublas-dev                   # [gpu_variant == "cuda-12"]
+        - cuda-nvtx-dev                   # [gpu_variant == "cuda-12"]
         - cmake
+        # Uncomment to use ccache, see README and build_pytorch.sh
+        # - ccache
         - git                             # [unix]
         - patch                           # [not win]
         - m2-patch                        # [win]
@@ -108,11 +121,25 @@ outputs:
         - llvm-openmp 14.0.6              # [osx and not (blas_impl == "mkl")]
       host:
         # GPU requirements
-        - cudatoolkit {{ cudatoolkit }}*  # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - cudnn {{ cudnn }}*              # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - magma 2.7.1                     # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        # (nccl is currently vendored-in)
+        - cudatoolkit {{ cudatoolkit }}*  # [gpu_variant == "cuda-11"]
+        - cudnn {{ cudnn }}*              # [(gpu_variant or "").startswith("cuda")]
+        - magma 2.7.1                     # [(gpu_variant or "").startswith("cuda")]
+        - cuda-version {{ cudatoolkit }}  # [gpu_variant == "cuda-11"]
+        - cuda-driver-dev                 # [gpu_variant == "cuda-12"]
+        - cuda-cudart-dev                 # [gpu_variant == "cuda-12"]
+        - cuda-nvrtc-dev                  # [gpu_variant == "cuda-12"]
+        - cuda-nvtx-dev                   # [gpu_variant == "cuda-12"]
+        - cuda-nvml-dev                   # [gpu_variant == "cuda-12"]
+        - cuda-profiler-api               # [gpu_variant == "cuda-12"]
+        - libcublas-dev                   # [gpu_variant == "cuda-12"]
+        - libcufft-dev                    # [gpu_variant == "cuda-12"]
+        - libcurand-dev                   # [gpu_variant == "cuda-12"]
+        - libcusolver-dev                 # [gpu_variant == "cuda-12"]
+        - libcusparse-dev                 # [gpu_variant == "cuda-12"]
         # Required for GPU profiler
-        - cupti 11.8.0                    # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        - cupti {{ cudatoolkit }}*        # [gpu_variant == "cuda-11"]
+        - cuda-cupti                      # [gpu_variant == "cuda-12"]
         # OpenBLAS or MKL
         - mkl-devel {{ mkl }}.*           # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}   # [blas_impl == "openblas"]
@@ -143,27 +170,34 @@ outputs:
         - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
         - llvm-openmp                            # [osx and not (blas_impl == "mkl")]
         # GPU requirements
-        - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - {{ pin_compatible('cudnn') }}                       # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [gpu_variant == "cuda-11"]
+        - {{ pin_compatible('cudnn') }}                       # [(gpu_variant or "").startswith("cuda")]
         # Required for GPU profiler
-        - cupti                           # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        - {{ pin_compatible('cupti') }}                       # [gpu_variant == "cuda-11"]
+        - {{ pin_compatible('cuda-cupti') }}                  # [gpu_variant == "cuda-12"]
         # other requirements
         # CF: needed to load C++ extensions
         - {{ pin_compatible('numpy') }}
         - python
         - typing_extensions >=4.8.0
         # To stop the compiler pulling in an openmp implementation itself
-        - _openmp_mutex                   # [linux]
-        - magma                           # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        - _openmp_mutex                                       # [linux]
+        - {{ pin_compatible('magma') }}                       # [(gpu_variant or "").startswith("cuda")]
         - filelock
         - jinja2
         - networkx
         - sympy
         - fsspec
-        - __cuda >={{ cudatoolkit }}      # [(pytorch_variant == "gpu") and (linux and x86_64)]
+        # Required to support torch.compile. This is tested in smoke_test.py, which is required to pass
+        # torch.compile isn't supported on python 3.12 and we only build cuda for linux-64 at the moment
+        - torchtriton {{ '.'.join(version.split('.')[:2]) }}.*       # [(gpu_variant or "").startswith("cuda") and (linux and x86_64) and (py!=312)]
+        - __cuda >={{ cudatoolkit }}                                 # [gpu_variant == "cuda-11"]
+        # For cuda-12, the version constraint is handled in cuda-version as a run_constrained.
+        # However, that doesn't enforce that the package requires a GPU; that needs to be done here.
+        - __cuda                                                     # [(gpu_variant or "").startswith("cuda")]
         # On macOS, the GPU accelerated backend, MPS, can be used from macOS v12.3. This isn't tightly dependent on the
         # SDK version used.
-        - __osx >=12.3                    # [(pytorch_variant == "gpu") and (osx and arm64)]
+        - __osx >=12.3                                               # [gpu_variant == "metal"]
       run_constrained:
         # current intel-openmp builds are incompatible with llvm-openmp on osx-64
         - llvm-openmp <0a0                # [(blas_impl == "mkl") and (osx and x86_64)]  
@@ -195,35 +229,40 @@ outputs:
         - tools/
       commands:
         # the smoke test script takes a bunch of env variables, defined below
-        - set MATRIX_GPU_ARCH_VERSION="{{ '.'.join(cudatoolkit.split('.')[:2]) }}"    # [(pytorch_variant == "gpu") and (win)]
-        - set MATRIX_GPU_ARCH_TYPE="cuda"                                             # [(pytorch_variant == "gpu") and (win)]
-        - set MATRIX_GPU_ARCH_VERSION="none"                                          # [(pytorch_variant == "cpu") and (win)]
-        - set MATRIX_GPU_ARCH_TYPE="none"                                             # [(pytorch_variant == "cpu") and (win)]
-        - set MATRIX_CHANNEL="defaults"                                               # [win]
-        - set MATRIX_STABLE_VERSION={{ version }}                                     # [win]
-        - set MATRIX_PACKAGE_TYPE="conda"                                             # [win]
-        - set TARGET_OS="windows"                                                     # [win]
-        - export MATRIX_GPU_ARCH_VERSION="{{ '.'.join(cudatoolkit.split('.')[:2]) }}" # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - export MATRIX_GPU_ARCH_VERSION="{{ MACOSX_SDK_VERSION }}"                   # [(pytorch_variant == "gpu") and (osx and arm64)]
-        - export MATRIX_GPU_ARCH_TYPE="cuda"                                          # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - export MATRIX_GPU_ARCH_TYPE="mps"                                           # [(pytorch_variant == "gpu") and (osx and arm64)]
-        - export MATRIX_GPU_ARCH_VERSION="none"                                       # [(pytorch_variant == "cpu") and (not win)]
-        - export MATRIX_GPU_ARCH_TYPE="none"                                          # [(pytorch_variant == "cpu") and (not win)]
-        - export MATRIX_CHANNEL="defaults"                                            # [not win]
-        - export MATRIX_STABLE_VERSION="{{ version }}"                                # [not win]
-        - export MATRIX_PACKAGE_TYPE="conda"                                          # [not win]
-        - export TARGET_OS="linux"                                                    # [linux]
-        - export TARGET_OS="macos-arm64"                                              # [(osx and arm64)]
-        - export TARGET_OS="macos-x86_64"                                             # [(osx and x86_64)]
+        - set MATRIX_GPU_ARCH_VERSION="{{ '.'.join(cudatoolkit.split('.')[:2]) }}"              # [(gpu_variant == "cuda-11") and (win)]
+        - set MATRIX_GPU_ARCH_VERSION="{{ '.'.join(cuda_compiler_version.split('.')[:2]) }}"    # [(gpu_variant == "cuda-12") and (win)]
+        - set MATRIX_GPU_ARCH_TYPE="cuda"                                                       # [(gpu_variant or "").startswith("cuda") and (win)]
+        - set MATRIX_GPU_ARCH_VERSION="none"                                                    # [(gpu_variant == "cpu") and (win)]
+        - set MATRIX_GPU_ARCH_TYPE="none"                                                       # [(gpu_variant == "cpu") and (win)]
+        - set MATRIX_CHANNEL="defaults"                                                         # [win]
+        - set MATRIX_STABLE_VERSION={{ version }}                                               # [win]
+        - set MATRIX_PACKAGE_TYPE="conda"                                                       # [win]
+        - set TARGET_OS="windows"                                                               # [win]
+        - export MATRIX_GPU_ARCH_VERSION="{{ '.'.join(cudatoolkit.split('.')[:2]) }}"           # [(gpu_variant == "cuda-11") and (linux and x86_64)]
+        - export MATRIX_GPU_ARCH_VERSION="{{ '.'.join(cuda_compiler_version.split('.')[:2]) }}" # [(gpu_variant == "cuda-12") and (linux and x86_64)]
+        - export MATRIX_GPU_ARCH_VERSION="{{ MACOSX_SDK_VERSION }}"                             # [(gpu_variant == "metal")]
+        - export MATRIX_GPU_ARCH_TYPE="cuda"                                                    # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
+        - export MATRIX_GPU_ARCH_TYPE="mps"                                                     # [(gpu_variant == "metal")]
+        - export MATRIX_GPU_ARCH_VERSION="none"                                                 # [(gpu_variant == "cpu") and (not win)]
+        - export MATRIX_GPU_ARCH_TYPE="none"                                                    # [(gpu_variant == "cpu") and (not win)]
+        - export MATRIX_CHANNEL="defaults"                                                      # [not win]
+        - export MATRIX_STABLE_VERSION="{{ version }}"                                          # [not win]
+        - export MATRIX_PACKAGE_TYPE="conda"                                                    # [not win]
+        - export TARGET_OS="linux"                                                              # [linux]
+        - export TARGET_OS="macos-arm64"                                                        # [(osx and arm64)]
+        - export TARGET_OS="macos-x86_64"                                                       # [(osx and x86_64)]
         - python ./smoke_test.py --package torchonly
         # We seem to have individual platform-specific test failures or flaky
         # tests, but the majority of tests pass.
         # Note that the `|| true` expression will make the build continue even if the whole script falls over completely
         # (for example, in the case of missing imports). There doesn't seem to be a way of making a script exception return
         # non-zero but failing tests return zero.
-        # The inductor tests test the torch.compile backend
-        - python ./test/run_test.py --inductor --continue-through-error || true       # [(pytorch_variant == "gpu") and (linux and x86_64)]
         - python ./test/run_test.py --core --continue-through-error || true
+         # The inductor tests test the torch.compile backend. Using the options below avoids running distributed tests,
+         # which would be run if we used the --inductor option. (Distributed tests would only be correctly run on a multi-gpu test platform,
+         # which we don't have.)
+         # torch.compile isn't supported on python 3.12 yet
+        - python test/run_test.py -i inductor/test_torchinductor.py --continue-through-error || true                 # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
         # Run pip check so as to ensure that all pytorch packages are installed
         # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/24
         - pip check
@@ -233,12 +272,12 @@ outputs:
         - python -c "import numpy; import torch"
         # distributed support is enabled by default on linux; for mac, we enable it manually in build.sh
         - python -c "import torch; assert torch.distributed.is_available()"        # [linux or osx]
-        - python -c "import torch; assert torch.backends.mkldnn.m.is_available()"  # [x86 and cuda_compiler_version == "None"]
-        - python -c "import torch; assert torch.backends.cuda.is_built()"          # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - python -c "import torch; assert torch.cuda.is_available()"               # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - python -c "import torch; assert torch.backends.cudnn.enabled"            # [(pytorch_variant == "gpu") and (linux and x86_64)]
-        - python -c "import torch; assert torch.backends.mps.is_built()"           # [(pytorch_variant == "gpu") and (osx and arm64)]
+        - python -c "import torch; assert torch.backends.mkldnn.m.is_available()"  # [blas_impl == "mkl"]
+        - python -c "import torch; assert torch.backends.cuda.is_built()"          # [(gpu_variant or "").startswith("cuda")]
+        - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [(gpu_variant or "").startswith("cuda")]
+        - python -c "import torch; assert torch.cuda.is_available()"               # [(gpu_variant or "").startswith("cuda")]
+        - python -c "import torch; assert torch.backends.cudnn.enabled"            # [(gpu_variant or "").startswith("cuda")]
+        - python -c "import torch; assert torch.backends.mps.is_built()"           # [(gpu_variant == "metal")]
 
 about:
   home: https://pytorch.org/

--- a/recipe/patches/0005-fix-triton-hash-with-backend.patch
+++ b/recipe/patches/0005-fix-triton-hash-with-backend.patch
@@ -1,0 +1,17 @@
+Apply patch at https://github.com/pytorch/pytorch/pull/128159
+
+It was causing the error seen here https://github.com/pytorch/pytorch/issues/127637
+
+
+Index: pytorch/torch/utils/_triton.py
+===================================================================
+--- pytorch.orig/torch/utils/_triton.py	2024-05-03 14:37:03.959311601 -0500
++++ pytorch/torch/utils/_triton.py	2024-06-26 14:46:04.562956833 -0500
+@@ -100,4 +100,6 @@
+ 
+     backend_hash = triton_backend_hash()
+     key = f"{triton_key()}-{backend_hash}"
+-    return hashlib.sha256(key.encode("utf-8")).hexdigest()
++
++    # Hash is upper case so that it can't contain any Python keywords.
++    return hashlib.sha256(key.encode("utf-8")).hexdigest().upper()


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4784](https://anaconda.atlassian.net/browse/PKG-3612?atlOrigin=eyJpIjoiNmY2MWNiZWM2NmMyNDQwNDg5YTU3YzVlYzNjODhlYzEiLCJwIjoiaiJ9) 
- [Upstream repository](https://github.com/pytorch/pytorch)

### Explanation of changes:

- Adds CUDA v11.8 support. Note Pytorch v2.3.0 [doesn't support CUDA v12.4](https://github.com/pytorch/pytorch/issues/126692)

Additionally:
- updating pytorch_variant config to include cuda-12 and renaming it gpu_variant
- adding the individual cudatoolkit components required for cuda 12
- Tidying up the selectors for readability
- Updating build_pytorch.sh to handle GPU variants
- Tidying up cbc.yaml for clarity and usability
- adding torchtriton to support torch.compile
- Updating smoke test for v2.3.0, including the required env variables
- Running inductor, but not distributed,  tests for CUDA variants
- Removing make; pytorch's build system seems to pick it up instead of using ninja
- Adding some info on handling long builds to README
- Adjusting (increasing) MAX_JOBS on unix
- Limiting CUDA variant to below python 3.12, as a key feature isn't yet supported
- Backporting patch from upstream main branch to solve a very edge-casey bug

### Build log

This build was done manually, log is [here](https://drive.google.com/file/d/1-KRhF1qSAaKooXsk7ikrRKZPmBR6XOEE/view?usp=sharing)

[PKG-3612]: https://anaconda.atlassian.net/browse/PKG-3612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-4784]: https://anaconda.atlassian.net/browse/PKG-4784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ