### PR TITLE
Rebuild against protobuf 4.25.3, bugfix for segfault skip CI

### DIFF
--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -208,4 +208,4 @@ export MAX_JOBS=$((CPU_COUNT > 1 ? CPU_COUNT - 1 : 1))
 
 # The Pytorch build system is invoked
 # via their setup.py
-"$PYTHON" -m pip install . --no-deps --no-build-isolation -v
+"$PYTHON" -m pip install . --no-deps --no-build-isolation --no-binary :all: --no-clean -v

--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -208,4 +208,4 @@ export MAX_JOBS=$((CPU_COUNT > 1 ? CPU_COUNT - 1 : 1))
 
 # The Pytorch build system is invoked
 # via their setup.py
-"$PYTHON" -m pip install . --no-deps --no-build-isolation --no-binary :all: --no-clean -v
+"$PYTHON" -m pip install . --no-deps --no-build-isolation -v

--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -77,6 +77,7 @@ export BUILD_DOCS=OFF     # This is the default, but just in case it changes one
 # Use our sleef (only available on osx-arm64), protobuf,
 # Pybind, Eigen packages, rather than the ones submodule'd
 # into the Pytorch source tree
+# Unvendoring onnx requires our package to provide ONNXConfig.cmake etc first
 if [[ "${build_platform}" = "osx-arm64" ]]; then
     export USE_SYSTEM_SLEEF=1
 fi

--- a/recipe/build_pytorch.sh
+++ b/recipe/build_pytorch.sh
@@ -84,6 +84,8 @@ fi
 export BUILD_CUSTOM_PROTOBUF=OFF
 export USE_SYSTEM_PYBIND11=1
 export USE_SYSTEM_EIGEN_INSTALL=1
+# If not set, libomp is embedded into the package on osx
+export PACKAGE_TYPE="conda"
 
 # Breakpad is missing a ppc64 and s390x port
 case "$build_platform" in

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -266,6 +266,7 @@ outputs:
          # which we don't have.)
          # torch.compile isn't supported on python 3.12 yet
         - python test/run_test.py -i inductor/test_torchinductor.py --continue-through-error || true                 # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
+        - python ./test/run_test.py --mps --continue-through-error || true                                           # [(gpu_variant == "metal")]
         # Run pip check so as to ensure that all pytorch packages are installed
         # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/24
         - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,6 @@ build:
   # torch.compile isn't supported with python 3.12:
   # https://github.com/pytorch/pytorch/blob/97ff6cfd9c86c5c09d7ce775ab64ec5c99230f5d/test/test_transformers.py#L3418
   skip: True  # [py==312 and (gpu_variant or "").startswith("cuda")]
-  # for testing
-  skip: True  # [not (osx and arm64)]
-  skip: True  # [not py==312]
 
 {% if rc %}
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,6 +154,9 @@ outputs:
         - llvm-openmp 14.0.6              # [osx and not (blas_impl == "mkl")]
         # Other requirements
         - libprotobuf {{ libprotobuf }}   # [not win]
+        # libabseil is linked against via the vendored-in onnx when
+        # it's in the environment. libprotobuf pulls it in anyway, so we should make it an explicit dependency.
+        - libabseil {{ libabseil }}       # [not win]
         # on osx, libuv supports torch.distributed support. See build.sh.
         - libuv 1.44.2                    # [win or osx]
         - numpy {{ numpy }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ build:
   # torch.compile isn't supported with python 3.12:
   # https://github.com/pytorch/pytorch/blob/97ff6cfd9c86c5c09d7ce775ab64ec5c99230f5d/test/test_transformers.py#L3418
   skip: True  # [py==312 and (gpu_variant or "").startswith("cuda")]
+  # for testing
+  skip: True  # [not (osx and arm64)]
+  skip: True  # [not py==312]
 
 {% if rc %}
 requirements:
@@ -82,7 +85,6 @@ outputs:
         - "**/libtorch_cpu.dylib"     # [osx]
         - "**/libtorch_python.dylib"  # [osx]
         - "**/libiomp5.dylib"         # [osx]
-        - "**/libomp.dylib"           # [osx]
         - "**/libc++.1.dylib"         # [osx]
         # conda-build also can't find these on Windows sometimes, for example Python 3.8, in Powershell with cygwin added to
         # the PATH. Error message is "$RPATH/<libname>.dll not found". Maybe RPATH isn't being defined correctly?

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
 {% set sha256 = "69579513b26261bbab32e13b7efc99ad287fcf3103087f2d4fdf1adacd25316f" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: pytorch-select


### PR DESCRIPTION
**Destination channel:** defaults

If a review contingent on builds succeeding is possible, that would be helpful to save time

### Explanation of changes:

- rebuild with new protobuf
- needs libabseil, see comments in feedstock as to why
- additionally, [bugfix](https://anaconda.atlassian.net/browse/PKG-5454?atlOrigin=eyJpIjoiY2ZkOGJiZGJjNGM1NGQyYmEzYzgzOTY1NjJiOGI4MDIiLCJwIjoiaiJ9)
