### PR TITLE
PKG-6040 v2.3.1 and numpy 2 rebuild skip CI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,6 @@ build:
   # torch.compile isn't supported with python 3.12:
   # https://github.com/pytorch/pytorch/blob/97ff6cfd9c86c5c09d7ce775ab64ec5c99230f5d/test/test_transformers.py#L3418
   skip: True  # [py==312 and (gpu_variant or "").startswith("cuda")]
-  # remove if you see this - just because the other subdirs are building ok.
-  skip: True  # [not win]
 
 {% if rc %}
 requirements:
@@ -160,7 +158,7 @@ outputs:
         - libabseil {{ libabseil }}       # [not win]
         # on osx, libuv supports torch.distributed support. See build.sh.
         - libuv 1.44.2                    # [win or osx]
-        - numpy {{ numpy }}
+        - numpy 2.0.0
         - pip                             # Required for in tree builds
         - python
         - pyyaml
@@ -185,7 +183,8 @@ outputs:
         - {{ pin_compatible('cuda-cupti') }}                  # [gpu_variant == "cuda-12"]
         # other requirements
         # CF: needed to load C++ extensions
-        - {{ pin_compatible('numpy') }}
+        # see https://github.com/pytorch/pytorch/blob/v2.3.0/RELEASE.md#tldr
+        - numpy >=1.22.4 <3.0.0
         - python
         - typing_extensions >=4.8.0
         # To stop the compiler pulling in an openmp implementation itself

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ build:
   # torch.compile isn't supported with python 3.12:
   # https://github.com/pytorch/pytorch/blob/97ff6cfd9c86c5c09d7ce775ab64ec5c99230f5d/test/test_transformers.py#L3418
   skip: True  # [py==312 and (gpu_variant or "").startswith("cuda")]
+  # remove if you see this - just because the other subdirs are building ok.
+  skip: True  # [not win]
 
 {% if rc %}
 requirements:
@@ -163,7 +165,8 @@ outputs:
         - python
         - pyyaml
         - requests
-        - setuptools
+        # https://github.com/pytorch/pytorch/issues/136541
+        - setuptools <=72.1.0
         - sleef 3.5.1                     # [osx and arm64]
         - typing_extensions >=4.8.0
         - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "2.3.0" %}
+{% set version = "2.3.1" %}
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
-{% set sha256 = "69579513b26261bbab32e13b7efc99ad287fcf3103087f2d4fdf1adacd25316f" %}
+{% set sha256 = "6c66b59345091907cd62a693b647cee224558e7f15a9b04f4f322f4f6ffeb75b" %}
 {% set build_number = 1 %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -184,7 +184,7 @@ outputs:
         # other requirements
         # CF: needed to load C++ extensions
         # see https://github.com/pytorch/pytorch/blob/v2.3.0/RELEASE.md#tldr
-        - numpy >=1.22.4 <3.0.0
+        - numpy >=1.22.4,<3.0.0
         - python
         - typing_extensions >=4.8.0
         # To stop the compiler pulling in an openmp implementation itself

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
 {% set sha256 = "6c66b59345091907cd62a693b647cee224558e7f15a9b04f4f322f4f6ffeb75b" %}
-{% set build_number = 1 %}
+{% set build_number = 0 %}
 
 package:
   name: pytorch-select


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6040](https://anaconda.atlassian.net/browse/PKG-6040) 
- [Upstream repository](https://github.com/pytorch/pytorch/tree/v2.3.1)

### Explanation of changes:

- straightforward version/sha bump
- Required for bugfix or security fix (can't remember)
- Also build with numpy 2.0.0 to satisfy https://anaconda.atlassian.net/browse/PKG-4839
- CUDA builds are on dev machine.
[log](https://github.com/user-attachments/files/17706623/2numpy2.log.zip)
- will transfer builds from staging channel rather than rebuilding on merge

[PKG-6040]: https://anaconda.atlassian.net/browse/PKG-6040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ