### PR TITLE
CI SKIP Fix/libtorch cmake

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -117,8 +117,8 @@ if "%PKG_NAME%" == "libtorch" (
   %PYTHON% setup.py bdist_wheel
   :: Extract the compiled wheel into a temporary directory
   if not exist "%SRC_DIR%/dist" mkdir %SRC_DIR%/dist
-  pushd %SRC_DIR%/dist
-  for %%f in (../torch-*.whl) do (
+  pushd %SRC_DIR%\dist
+  for %%f in (torch-*.whl) do (
       wheel unpack %%f
   )
 
@@ -129,14 +129,12 @@ if "%PKG_NAME%" == "libtorch" (
 
   :: Do not package `fmt.lib` (and its metadata); delete it before the move into
   :: %LIBRARY_BIN% because it may exist in host before installation already
-  del torch\lib\fmt.lib torch\lib\pkgconfig\fmt.pc
+  del torch\lib\fmt.lib
   if %ERRORLEVEL% neq 0 exit 1
-  :: also delete rest of fmt metadata
-  rmdir /s /q torch\lib\cmake\fmt
 
   :: Move the binaries into the packages site-package directory
   :: the only content of torch\bin, {asmjit,fbgemm}.dll, also exists in torch\lib
-  robocopy /NP /NFL /NDL /NJH /E torch\lib\ %LIBRARY_BIN%\ torch*.dll c10.dll shm.dll asmjit.dll fbgemm.dll
+  robocopy /NP /NFL /NDL /NJH /E torch\bin\ %LIBRARY_BIN%\ torch*.dll c10.dll shm.dll asmjit.dll fbgemm.dll
   robocopy /NP /NFL /NDL /NJH /E torch\lib\ %LIBRARY_LIB%\ torch*.lib c10.lib shm.lib asmjit.lib fbgemm.lib
   if not "%cuda_compiler_version%" == "None" (
       robocopy /NP /NFL /NDL /NJH /E torch\lib\ %LIBRARY_BIN%\ c10_cuda.dll caffe2_nvrtc.dll
@@ -162,7 +160,7 @@ if "%PKG_NAME%" == "libtorch" (
   %PYTHON% -m pip install --find-links=dist torch --no-build-isolation --no-deps
 
   :: Move libtorch_python and remove the other directories afterwards.
-  robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\lib\ %LIBRARY_BIN%\ torch_python.dll
+  robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\bin\ %LIBRARY_BIN%\ torch_python.dll
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\lib\ %LIBRARY_LIB%\ torch_python.lib
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\lib\ %LIBRARY_LIB%\ _C.lib
   rmdir /s /q %SP_DIR%\torch\lib

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -183,3 +183,4 @@ if "%PKG_NAME%" == "libtorch" (
 )
 
 if %ERRORLEVEL% neq 0 exit 1
+exit /b 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -144,6 +144,9 @@ if "%PKG_NAME%" == "libtorch" (
   for %%f in (ATen caffe2 torch c10) do (
       robocopy /NP /NFL /NDL /NJH /E torch\include\%%f %LIBRARY_INC%\%%f\
   )
+  :: See return codes of robocopy:
+  ::https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility#introduction
+  if %ERRORLEVEL% leq 6 set ERRORLEVEL=0
 
   :: Remove the python binary file, that is placed in the site-packages
   :: directory by the specific python specific pytorch package.
@@ -163,6 +166,8 @@ if "%PKG_NAME%" == "libtorch" (
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\bin\ %LIBRARY_BIN%\ torch_python.dll
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\lib\ %LIBRARY_LIB%\ torch_python.lib
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\lib\ %LIBRARY_LIB%\ _C.lib
+  if %ERRORLEVEL% leq 6 set ERRORLEVEL=0
+
   rmdir /s /q %SP_DIR%\torch\lib
   rmdir /s /q %SP_DIR%\torch\bin
   rmdir /s /q %SP_DIR%\torch\share
@@ -174,7 +179,7 @@ if "%PKG_NAME%" == "libtorch" (
   :: needed to remove everything else.
   robocopy /NP /NFL /NDL /NJH /E %LIBRARY_LIB%\ torch\lib\ torch_python.lib
   robocopy /NP /NFL /NDL /NJH /E %LIBRARY_LIB%\ torch\lib\ _C.lib
+  if %ERRORLEVEL% leq 6 set ERRORLEVEL=0
 )
 
-if errorlevel 1 exit /b 1
-
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -105,7 +105,9 @@ unset CMAKE_INSTALL_PREFIX
 #export TH_BINARY_BUILD=1
 # Use our build version and number for inserting into binaries
 export PYTORCH_BUILD_VERSION=$PKG_VERSION
-export PYTORCH_BUILD_NUMBER=$PKG_BUILDNUM
+# Always pass 0 to avoid appending ".post" to version string.
+# https://github.com/conda-forge/pytorch-cpu-feedstock/issues/315
+export PYTORCH_BUILD_NUMBER=0
 
 export INSTALL_TEST=0
 export BUILD_TEST=0

--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(cf_dummy LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.12)
+find_package(Torch CONFIG REQUIRED)
+find_package(ATen CONFIG REQUIRED)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -191,6 +191,15 @@ requirements:
 # a particularity of conda-build, that output is defined in
 # the global build stage, including tests
 test:
+  requires:
+    # cmake needs a compiler to run package detection, see
+    # https://discourse.cmake.org/t/questions-about-find-package-cli-msvc/6194
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - pkg-config
+  files:
+    - cmake_test/
   commands:
     # libraries
     {% for each_lib in [ 'libc10', 'libshm', 'libtorch', 'libtorch_cpu', 'libtorch_global_deps'] %}
@@ -200,6 +209,10 @@ test:
     {% for each_lib in ['libc10_cuda', 'libcaffe2_nvrtc', 'libtorch_cuda', 'libtorch_cuda_linalg'] %}
     - test -f $PREFIX/lib/{{ each_lib }}.so     # [linux and (gpu_variant or "").startswith("cuda")]
     {% endfor %}
+        # test integrity of CMake metadata
+    - cd cmake_test
+    - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]
+    - cmake -GNinja -DCMAKE_CXX_STANDARD=17 %CMAKE_ARGS% .  # [win]
 
 outputs:
   - name: libtorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,9 @@ source:
       - patches/0007-continue-tests-on-failure.patch
       - patches/0008-add-missing-includes.patch
       - patches/0009-use-prefix-include-for-inductor.patch
+      - patches/0010-make-ATEN_INCLUDE_DIR-relative-to-TORCH_INSTALL_PREF.patch 
+      - patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch             # [win]
+      - patches_submodules/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch  # [win]
 
       # See https://github.com/pytorch/pytorch/pull/137331
       # for status

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set sha256 = "740eb5fff95e33cfe699bad43be83523f569c7cc7f9c285c2a255416443dd266" %}
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # Keep this in sync with the release
 {% set smoke_test_commit = "8757658a36dfc1d7c85da543bd424ce1cc546f74" %}

--- a/recipe/patches/0010-make-ATEN_INCLUDE_DIR-relative-to-TORCH_INSTALL_PREF.patch
+++ b/recipe/patches/0010-make-ATEN_INCLUDE_DIR-relative-to-TORCH_INSTALL_PREF.patch
@@ -1,0 +1,25 @@
+From b0cfa0f728e96a3a9d6f7434e2c02d74d6daa9a9 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 28 Jan 2025 14:15:34 +1100
+Subject: [PATCH 18/19] make ATEN_INCLUDE_DIR relative to TORCH_INSTALL_PREFIX
+
+we cannot set CMAKE_INSTALL_PREFIX without the pytorch build complaining, but we can
+use TORCH_INSTALL_PREFIX, which is set correctly relative to our CMake files already:
+https://github.com/pytorch/pytorch/blob/v2.5.1/cmake/TorchConfig.cmake.in#L47
+---
+ aten/src/ATen/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index 6d9152a4d07..aa4dd7b05cc 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -563,7 +563,7 @@ if(USE_ROCM)
+   # list(APPEND ATen_HIP_DEPENDENCY_LIBS ATEN_CUDA_FILES_GEN_LIB)
+ endif()
+ 
+-set(ATEN_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${AT_INSTALL_INCLUDE_DIR}")
++set(ATEN_INCLUDE_DIR "${TORCH_INSTALL_PREFIX}/${AT_INSTALL_INCLUDE_DIR}")
+ configure_file(ATenConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/cmake-exports/ATenConfig.cmake")
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake-exports/ATenConfig.cmake"
+   DESTINATION "${AT_INSTALL_SHARE_DIR}/cmake/ATen")

--- a/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
+++ b/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
@@ -1,0 +1,158 @@
+From f7db4cbfb0af59027ed8bdcd0387dba6fbcb1192 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 28 Jan 2025 10:58:29 +1100
+Subject: [PATCH 19/19] remove `DESTINATION lib` from CMake `install(TARGETS`
+ directives
+
+Suggested-By: Silvio Traversaro <silvio@traversaro.it>
+---
+ c10/CMakeLists.txt                      |  2 +-
+ c10/cuda/CMakeLists.txt                 |  2 +-
+ c10/hip/CMakeLists.txt                  |  2 +-
+ c10/xpu/CMakeLists.txt                  |  2 +-
+ caffe2/CMakeLists.txt                   | 18 +++++++++---------
+ torch/CMakeLists.txt                    |  2 +-
+ torch/lib/libshm_windows/CMakeLists.txt |  2 +-
+ 7 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/c10/CMakeLists.txt b/c10/CMakeLists.txt
+index 80e172497d5..d7f8987020d 100644
+--- a/c10/CMakeLists.txt
++++ b/c10/CMakeLists.txt
+@@ -162,7 +162,7 @@ if(NOT BUILD_LIBTORCHLESS)
+   # Note: for now, we will put all export path into one single Caffe2Targets group
+   # to deal with the cmake deployment need. Inside the Caffe2Targets set, the
+   # individual libraries like libc10.so and libcaffe2.so are still self-contained.
+-  install(TARGETS c10 EXPORT Caffe2Targets DESTINATION lib)
++  install(TARGETS c10 EXPORT Caffe2Targets)
+ endif()
+ 
+ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+diff --git a/c10/cuda/CMakeLists.txt b/c10/cuda/CMakeLists.txt
+index 3327dab4779..9336c9e8f77 100644
+--- a/c10/cuda/CMakeLists.txt
++++ b/c10/cuda/CMakeLists.txt
+@@ -82,7 +82,7 @@ if(NOT BUILD_LIBTORCHLESS)
+ # Note: for now, we will put all export path into one single Caffe2Targets group
+ # to deal with the cmake deployment need. Inside the Caffe2Targets set, the
+ # individual libraries like libc10.so and libcaffe2.so are still self-contained.
+-install(TARGETS c10_cuda EXPORT Caffe2Targets DESTINATION lib)
++install(TARGETS c10_cuda EXPORT Caffe2Targets)
+ 
+ endif()
+ 
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index f153030e793..514c6d29266 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -55,7 +55,7 @@ if(NOT BUILD_LIBTORCHLESS)
+       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+       $<INSTALL_INTERFACE:include>)
+-  install(TARGETS c10_hip EXPORT Caffe2Targets DESTINATION lib)
++  install(TARGETS c10_hip EXPORT Caffe2Targets)
+   set(C10_HIP_LIB c10_hip)
+ endif()
+ 
+diff --git a/c10/xpu/CMakeLists.txt b/c10/xpu/CMakeLists.txt
+index 01f77d61713..437ade657f9 100644
+--- a/c10/xpu/CMakeLists.txt
++++ b/c10/xpu/CMakeLists.txt
+@@ -45,7 +45,7 @@ if(NOT BUILD_LIBTORCHLESS)
+       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+       $<INSTALL_INTERFACE:include>
+       )
+-  install(TARGETS c10_xpu EXPORT Caffe2Targets DESTINATION lib)
++  install(TARGETS c10_xpu EXPORT Caffe2Targets)
+   set(C10_XPU_LIB c10_xpu)
+   add_subdirectory(test)
+ endif()
+diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
+index 9be7f3732f3..b51c7cc637b 100644
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -549,7 +549,7 @@ if(USE_CUDA)
+   endif()
+ 
+   target_link_libraries(caffe2_nvrtc PRIVATE caffe2::nvrtc ${DELAY_LOAD_FLAGS})
+-  install(TARGETS caffe2_nvrtc DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++  install(TARGETS caffe2_nvrtc)
+   if(USE_NCCL)
+     list(APPEND Caffe2_GPU_SRCS
+       ${TORCH_SRC_DIR}/csrc/cuda/nccl.cpp)
+@@ -609,7 +609,7 @@ if(USE_ROCM)
+   target_link_libraries(caffe2_nvrtc ${PYTORCH_HIP_LIBRARIES} ${ROCM_HIPRTC_LIB})
+   target_include_directories(caffe2_nvrtc PRIVATE ${CMAKE_BINARY_DIR})
+   target_compile_definitions(caffe2_nvrtc PRIVATE USE_ROCM __HIP_PLATFORM_AMD__)
+-  install(TARGETS caffe2_nvrtc DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++  install(TARGETS caffe2_nvrtc)
+ endif()
+ 
+ if(NOT NO_API AND NOT BUILD_LITE_INTERPRETER)
+@@ -995,7 +995,7 @@ elseif(USE_CUDA)
+           CUDA::culibos ${CMAKE_DL_LIBS})
+     endif()
+     set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/../aten/src/ATen/native/cuda/LinearAlgebraStubs.cpp PROPERTIES COMPILE_FLAGS "-DBUILD_LAZY_CUDA_LINALG")
+-    install(TARGETS torch_cuda_linalg DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++    install(TARGETS torch_cuda_linalg)
+   endif()
+ 
+   if(USE_PRECOMPILED_HEADERS)
+@@ -1467,17 +1467,17 @@ endif()
+ 
+ caffe2_interface_library(torch torch_library)
+ 
+-install(TARGETS torch_cpu torch_cpu_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++install(TARGETS torch_cpu torch_cpu_library EXPORT Caffe2Targets)
+ 
+ if(USE_CUDA)
+-  install(TARGETS torch_cuda torch_cuda_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++  install(TARGETS torch_cuda torch_cuda_library EXPORT Caffe2Targets)
+ elseif(USE_ROCM)
+-  install(TARGETS torch_hip torch_hip_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++  install(TARGETS torch_hip torch_hip_library EXPORT Caffe2Targets)
+ elseif(USE_XPU)
+-  install(TARGETS torch_xpu torch_xpu_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++  install(TARGETS torch_xpu torch_xpu_library EXPORT Caffe2Targets)
+ endif()
+ 
+-install(TARGETS torch torch_library EXPORT Caffe2Targets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++install(TARGETS torch torch_library EXPORT Caffe2Targets)
+ 
+ target_link_libraries(torch PUBLIC torch_cpu_library)
+ 
+@@ -1616,7 +1616,7 @@ if(BUILD_SHARED_LIBS)
+       target_link_libraries(torch_global_deps torch::nvtoolsext)
+     endif()
+   endif()
+-  install(TARGETS torch_global_deps DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++  install(TARGETS torch_global_deps)
+ endif()
+ 
+ # ---[ Caffe2 HIP sources.
+diff --git a/torch/CMakeLists.txt b/torch/CMakeLists.txt
+index c74b45431c9..80fb5e7734e 100644
+--- a/torch/CMakeLists.txt
++++ b/torch/CMakeLists.txt
+@@ -447,7 +447,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
+     set_target_properties(torch_python PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
+ endif()
+ 
+-install(TARGETS torch_python DESTINATION "${TORCH_INSTALL_LIB_DIR}")
++install(TARGETS torch_python)
+ 
+ # Generate torch/version.py from the appropriate CMake cache variables.
+ if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+diff --git a/torch/lib/libshm_windows/CMakeLists.txt b/torch/lib/libshm_windows/CMakeLists.txt
+index df2a1064938..5fa15e6be31 100644
+--- a/torch/lib/libshm_windows/CMakeLists.txt
++++ b/torch/lib/libshm_windows/CMakeLists.txt
+@@ -19,7 +19,7 @@ target_include_directories(shm PRIVATE
+ target_link_libraries(shm torch c10)
+ 
+ 
+-install(TARGETS shm DESTINATION "${LIBSHM_INSTALL_LIB_SUBDIR}")
++install(TARGETS shm)
+ install(FILES libshm.h DESTINATION "include")
+ 
+ if(MSVC AND BUILD_SHARED_LIBS)

--- a/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
+++ b/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
@@ -1,21 +1,22 @@
-From f403f82620ac2e71427789a417b70f0835c80002 Mon Sep 17 00:00:00 2001
+From f7db4cbfb0af59027ed8bdcd0387dba6fbcb1192 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 28 Jan 2025 10:58:29 +1100
-Subject: [PATCH 18/19] remove `DESTINATION lib` from CMake install directives
+Subject: [PATCH 19/19] remove `DESTINATION lib` from CMake `install(TARGETS`
+ directives
 
 Suggested-By: Silvio Traversaro <silvio@traversaro.it>
 ---
- c10/CMakeLists.txt                      |  4 ++--
- c10/cuda/CMakeLists.txt                 |  4 ++--
+ c10/CMakeLists.txt                      |  2 +-
+ c10/cuda/CMakeLists.txt                 |  2 +-
  c10/hip/CMakeLists.txt                  |  2 +-
- c10/xpu/CMakeLists.txt                  |  4 ++--
- caffe2/CMakeLists.txt                   | 24 ++++++++++++------------
+ c10/xpu/CMakeLists.txt                  |  2 +-
+ caffe2/CMakeLists.txt                   | 18 +++++++++---------
  torch/CMakeLists.txt                    |  2 +-
- torch/lib/libshm_windows/CMakeLists.txt |  4 ++--
- 7 files changed, 22 insertions(+), 22 deletions(-)
+ torch/lib/libshm_windows/CMakeLists.txt |  2 +-
+ 7 files changed, 15 insertions(+), 15 deletions(-)
 
 diff --git a/c10/CMakeLists.txt b/c10/CMakeLists.txt
-index 80e172497d5..f792403016a 100644
+index 80e172497d5..d7f8987020d 100644
 --- a/c10/CMakeLists.txt
 +++ b/c10/CMakeLists.txt
 @@ -162,7 +162,7 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -27,15 +28,8 @@ index 80e172497d5..f792403016a 100644
  endif()
  
  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-@@ -172,5 +172,5 @@ install(FILES ${CMAKE_BINARY_DIR}/c10/macros/cmake_macros.h
-         DESTINATION include/c10/macros)
- 
- if(MSVC AND C10_BUILD_SHARED_LIBS)
--  install(FILES $<TARGET_PDB_FILE:c10> DESTINATION lib OPTIONAL)
-+  install(FILES $<TARGET_PDB_FILE:c10> OPTIONAL)
- endif()
 diff --git a/c10/cuda/CMakeLists.txt b/c10/cuda/CMakeLists.txt
-index 3327dab4779..ec91ab975b3 100644
+index 3327dab4779..9336c9e8f77 100644
 --- a/c10/cuda/CMakeLists.txt
 +++ b/c10/cuda/CMakeLists.txt
 @@ -82,7 +82,7 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -47,13 +41,6 @@ index 3327dab4779..ec91ab975b3 100644
  
  endif()
  
-@@ -96,5 +96,5 @@ install(FILES ${CMAKE_BINARY_DIR}/c10/cuda/impl/cuda_cmake_macros.h
-   DESTINATION include/c10/cuda/impl)
- 
- if(MSVC AND C10_CUDA_BUILD_SHARED_LIBS)
--  install(FILES $<TARGET_PDB_FILE:c10_cuda> DESTINATION lib OPTIONAL)
-+  install(FILES $<TARGET_PDB_FILE:c10_cuda> OPTIONAL)
- endif()
 diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
 index f153030e793..514c6d29266 100644
 --- a/c10/hip/CMakeLists.txt
@@ -68,7 +55,7 @@ index f153030e793..514c6d29266 100644
  endif()
  
 diff --git a/c10/xpu/CMakeLists.txt b/c10/xpu/CMakeLists.txt
-index 01f77d61713..32f1cdb4a5d 100644
+index 01f77d61713..437ade657f9 100644
 --- a/c10/xpu/CMakeLists.txt
 +++ b/c10/xpu/CMakeLists.txt
 @@ -45,7 +45,7 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -80,15 +67,8 @@ index 01f77d61713..32f1cdb4a5d 100644
    set(C10_XPU_LIB c10_xpu)
    add_subdirectory(test)
  endif()
-@@ -60,5 +60,5 @@ install(FILES ${CMAKE_BINARY_DIR}/c10/xpu/impl/xpu_cmake_macros.h
-   DESTINATION include/c10/xpu/impl)
- 
- if(MSVC AND C10_XPU_BUILD_SHARED_LIBS)
--  install(FILES $<TARGET_PDB_FILE:c10_xpu> DESTINATION lib OPTIONAL)
-+  install(FILES $<TARGET_PDB_FILE:c10_xpu> OPTIONAL)
- endif()
 diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index 9be7f3732f3..9a9c62f820d 100644
+index 9be7f3732f3..b51c7cc637b 100644
 --- a/caffe2/CMakeLists.txt
 +++ b/caffe2/CMakeLists.txt
 @@ -549,7 +549,7 @@ if(USE_CUDA)
@@ -141,21 +121,6 @@ index 9be7f3732f3..9a9c62f820d 100644
  
  target_link_libraries(torch PUBLIC torch_cpu_library)
  
-@@ -1498,11 +1498,11 @@ endif()
- 
- # Install PDB files for MSVC builds
- if(MSVC AND BUILD_SHARED_LIBS)
--  install(FILES $<TARGET_PDB_FILE:torch_cpu> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
-+  install(FILES $<TARGET_PDB_FILE:torch_cpu> OPTIONAL)
-   if(USE_CUDA)
--    install(FILES $<TARGET_PDB_FILE:torch_cuda> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
-+    install(FILES $<TARGET_PDB_FILE:torch_cuda> OPTIONAL)
-   elseif(USE_ROCM)
--    install(FILES $<TARGET_PDB_FILE:torch_hip> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
-+    install(FILES $<TARGET_PDB_FILE:torch_hip> OPTIONAL)
-   endif()
- endif()
- 
 @@ -1616,7 +1616,7 @@ if(BUILD_SHARED_LIBS)
        target_link_libraries(torch_global_deps torch::nvtoolsext)
      endif()
@@ -179,10 +144,10 @@ index c74b45431c9..80fb5e7734e 100644
  # Generate torch/version.py from the appropriate CMake cache variables.
  if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 diff --git a/torch/lib/libshm_windows/CMakeLists.txt b/torch/lib/libshm_windows/CMakeLists.txt
-index df2a1064938..cca92723bb5 100644
+index df2a1064938..5fa15e6be31 100644
 --- a/torch/lib/libshm_windows/CMakeLists.txt
 +++ b/torch/lib/libshm_windows/CMakeLists.txt
-@@ -19,9 +19,9 @@ target_include_directories(shm PRIVATE
+@@ -19,7 +19,7 @@ target_include_directories(shm PRIVATE
  target_link_libraries(shm torch c10)
  
  
@@ -191,6 +156,3 @@ index df2a1064938..cca92723bb5 100644
  install(FILES libshm.h DESTINATION "include")
  
  if(MSVC AND BUILD_SHARED_LIBS)
--  install(FILES $<TARGET_PDB_FILE:shm> DESTINATION "${LIBSHM_INSTALL_LIB_SUBDIR}" OPTIONAL)
-+  install(FILES $<TARGET_PDB_FILE:shm> OPTIONAL)
- endif()

--- a/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
+++ b/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
@@ -1,22 +1,21 @@
-From f7db4cbfb0af59027ed8bdcd0387dba6fbcb1192 Mon Sep 17 00:00:00 2001
+From f403f82620ac2e71427789a417b70f0835c80002 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 28 Jan 2025 10:58:29 +1100
-Subject: [PATCH 19/19] remove `DESTINATION lib` from CMake `install(TARGETS`
- directives
+Subject: [PATCH 18/19] remove `DESTINATION lib` from CMake install directives
 
 Suggested-By: Silvio Traversaro <silvio@traversaro.it>
 ---
- c10/CMakeLists.txt                      |  2 +-
- c10/cuda/CMakeLists.txt                 |  2 +-
+ c10/CMakeLists.txt                      |  4 ++--
+ c10/cuda/CMakeLists.txt                 |  4 ++--
  c10/hip/CMakeLists.txt                  |  2 +-
- c10/xpu/CMakeLists.txt                  |  2 +-
- caffe2/CMakeLists.txt                   | 18 +++++++++---------
+ c10/xpu/CMakeLists.txt                  |  4 ++--
+ caffe2/CMakeLists.txt                   | 24 ++++++++++++------------
  torch/CMakeLists.txt                    |  2 +-
- torch/lib/libshm_windows/CMakeLists.txt |  2 +-
- 7 files changed, 15 insertions(+), 15 deletions(-)
+ torch/lib/libshm_windows/CMakeLists.txt |  4 ++--
+ 7 files changed, 22 insertions(+), 22 deletions(-)
 
 diff --git a/c10/CMakeLists.txt b/c10/CMakeLists.txt
-index 80e172497d5..d7f8987020d 100644
+index 80e172497d5..f792403016a 100644
 --- a/c10/CMakeLists.txt
 +++ b/c10/CMakeLists.txt
 @@ -162,7 +162,7 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -28,8 +27,15 @@ index 80e172497d5..d7f8987020d 100644
  endif()
  
  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+@@ -172,5 +172,5 @@ install(FILES ${CMAKE_BINARY_DIR}/c10/macros/cmake_macros.h
+         DESTINATION include/c10/macros)
+ 
+ if(MSVC AND C10_BUILD_SHARED_LIBS)
+-  install(FILES $<TARGET_PDB_FILE:c10> DESTINATION lib OPTIONAL)
++  install(FILES $<TARGET_PDB_FILE:c10> OPTIONAL)
+ endif()
 diff --git a/c10/cuda/CMakeLists.txt b/c10/cuda/CMakeLists.txt
-index 3327dab4779..9336c9e8f77 100644
+index 3327dab4779..ec91ab975b3 100644
 --- a/c10/cuda/CMakeLists.txt
 +++ b/c10/cuda/CMakeLists.txt
 @@ -82,7 +82,7 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -41,6 +47,13 @@ index 3327dab4779..9336c9e8f77 100644
  
  endif()
  
+@@ -96,5 +96,5 @@ install(FILES ${CMAKE_BINARY_DIR}/c10/cuda/impl/cuda_cmake_macros.h
+   DESTINATION include/c10/cuda/impl)
+ 
+ if(MSVC AND C10_CUDA_BUILD_SHARED_LIBS)
+-  install(FILES $<TARGET_PDB_FILE:c10_cuda> DESTINATION lib OPTIONAL)
++  install(FILES $<TARGET_PDB_FILE:c10_cuda> OPTIONAL)
+ endif()
 diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
 index f153030e793..514c6d29266 100644
 --- a/c10/hip/CMakeLists.txt
@@ -55,7 +68,7 @@ index f153030e793..514c6d29266 100644
  endif()
  
 diff --git a/c10/xpu/CMakeLists.txt b/c10/xpu/CMakeLists.txt
-index 01f77d61713..437ade657f9 100644
+index 01f77d61713..32f1cdb4a5d 100644
 --- a/c10/xpu/CMakeLists.txt
 +++ b/c10/xpu/CMakeLists.txt
 @@ -45,7 +45,7 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -67,8 +80,15 @@ index 01f77d61713..437ade657f9 100644
    set(C10_XPU_LIB c10_xpu)
    add_subdirectory(test)
  endif()
+@@ -60,5 +60,5 @@ install(FILES ${CMAKE_BINARY_DIR}/c10/xpu/impl/xpu_cmake_macros.h
+   DESTINATION include/c10/xpu/impl)
+ 
+ if(MSVC AND C10_XPU_BUILD_SHARED_LIBS)
+-  install(FILES $<TARGET_PDB_FILE:c10_xpu> DESTINATION lib OPTIONAL)
++  install(FILES $<TARGET_PDB_FILE:c10_xpu> OPTIONAL)
+ endif()
 diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index 9be7f3732f3..b51c7cc637b 100644
+index 9be7f3732f3..9a9c62f820d 100644
 --- a/caffe2/CMakeLists.txt
 +++ b/caffe2/CMakeLists.txt
 @@ -549,7 +549,7 @@ if(USE_CUDA)
@@ -121,6 +141,21 @@ index 9be7f3732f3..b51c7cc637b 100644
  
  target_link_libraries(torch PUBLIC torch_cpu_library)
  
+@@ -1498,11 +1498,11 @@ endif()
+ 
+ # Install PDB files for MSVC builds
+ if(MSVC AND BUILD_SHARED_LIBS)
+-  install(FILES $<TARGET_PDB_FILE:torch_cpu> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
++  install(FILES $<TARGET_PDB_FILE:torch_cpu> OPTIONAL)
+   if(USE_CUDA)
+-    install(FILES $<TARGET_PDB_FILE:torch_cuda> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
++    install(FILES $<TARGET_PDB_FILE:torch_cuda> OPTIONAL)
+   elseif(USE_ROCM)
+-    install(FILES $<TARGET_PDB_FILE:torch_hip> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
++    install(FILES $<TARGET_PDB_FILE:torch_hip> OPTIONAL)
+   endif()
+ endif()
+ 
 @@ -1616,7 +1616,7 @@ if(BUILD_SHARED_LIBS)
        target_link_libraries(torch_global_deps torch::nvtoolsext)
      endif()
@@ -144,10 +179,10 @@ index c74b45431c9..80fb5e7734e 100644
  # Generate torch/version.py from the appropriate CMake cache variables.
  if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 diff --git a/torch/lib/libshm_windows/CMakeLists.txt b/torch/lib/libshm_windows/CMakeLists.txt
-index df2a1064938..5fa15e6be31 100644
+index df2a1064938..cca92723bb5 100644
 --- a/torch/lib/libshm_windows/CMakeLists.txt
 +++ b/torch/lib/libshm_windows/CMakeLists.txt
-@@ -19,7 +19,7 @@ target_include_directories(shm PRIVATE
+@@ -19,9 +19,9 @@ target_include_directories(shm PRIVATE
  target_link_libraries(shm torch c10)
  
  
@@ -156,3 +191,6 @@ index df2a1064938..5fa15e6be31 100644
  install(FILES libshm.h DESTINATION "include")
  
  if(MSVC AND BUILD_SHARED_LIBS)
+-  install(FILES $<TARGET_PDB_FILE:shm> DESTINATION "${LIBSHM_INSTALL_LIB_SUBDIR}" OPTIONAL)
++  install(FILES $<TARGET_PDB_FILE:shm> OPTIONAL)
+ endif()

--- a/recipe/patches_submodules/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch
+++ b/recipe/patches_submodules/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch
@@ -1,0 +1,25 @@
+From a9879bdd5ea793c5301a4b86f163a07e1f28f321 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 28 Jan 2025 13:32:28 +1100
+Subject: [PATCH] remove `DESTINATION lib` from CMake install directives
+
+Suggested-By: Silvio Traversaro <silvio@traversaro.it>
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/third_party/fbgemm/CMakeLists.txt b/third_party/fbgemm/CMakeLists.txt
+index 134523e7..86fb8fad 100644
+--- a/third_party/fbgemm/CMakeLists.txt
++++ b/third_party/fbgemm/CMakeLists.txt
+@@ -370,8 +370,8 @@ if(MSVC)
+       FILES $<TARGET_PDB_FILE:fbgemm> $<TARGET_PDB_FILE:asmjit>
+       DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
+   endif()
+-  install(TARGETS fbgemm DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  install(TARGETS asmjit DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  install(TARGETS fbgemm)
++  install(TARGETS asmjit)
+ endif()
+ 
+ #Make project importable from the build directory


### PR DESCRIPTION
pytorch 2.5.1 rebuild

## Changes
- Addresses https://github.com/conda-forge/pytorch-cpu-feedstock/issues/333 for the CPU variant
    - Adds a test to ensure cmake can utilize `find_package(Torch`
- Relocates dlls to `LIBRARY_BIN` and libs to `LIBRARY_LIB` (out of the `SP_DIR`)
- Removes extraneous binaries from libtorch that were causing 3x bloat in package size
- Fixes https://github.com/conda-forge/pytorch-cpu-feedstock/issues/315 for unix variants

## Notes
- Windows may still be building. I built this on a faster dev instance, build log it attached and artifacts are on https://anaconda.org/build/

[pytorch_102_build_1_31_25.log.zip](https://github.com/user-attachments/files/18621562/pytorch_102_build_1_31_25.log.zip)

