### PR TITLE
CI Skip 3.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,9 @@ build_env_vars:
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
+
+
+build_parameters:
+  - "--suppress-variables"
+  # - "--skip-existing"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  
 # macOS 12.3 or above is required for running the GPU variant (MPS support). No way to specify this for only the GPU
 # variant, so it's specified for both.
 extra_labels_for_os:

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,9 +5,3 @@ build_env_vars:
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
-
-
-build_parameters:
-  - "--suppress-variables"
-  # - "--skip-existing"
-  - "--error-overlinking"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -161,6 +161,7 @@ if "%PKG_NAME%" == "libtorch" (
   %PYTHON% setup.py clean
   %PYTHON% setup.py bdist_wheel --cmake
   %PYTHON% -m pip install --find-links=dist torch --no-build-isolation --no-deps
+  if %ERRORLEVEL% neq 0 exit 1
 
   :: Move libtorch_python and remove the other directories afterwards.
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\bin\ %LIBRARY_BIN%\ torch_python.dll

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -248,7 +248,7 @@ outputs:
       run_exports:
         - {{ pin_subpackage('pytorch', max_pin='x.x') }}
         - {{ pin_subpackage('libtorch', max_pin='x.x') }}
-      skip: True  # [py<39]
+      skip: True  # [py<313]
 
     script: build_pytorch.sh   # [unix]
     script: build_pytorch.bat  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -249,7 +249,7 @@ outputs:
       run_exports:
         - {{ pin_subpackage('pytorch', max_pin='x.x') }}
         - {{ pin_subpackage('libtorch', max_pin='x.x') }}
-      skip: True  # [py<313]
+      skip: True  # [py<39]
 
     script: build_pytorch.sh   # [unix]
     script: build_pytorch.bat  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ source:
       - patches/0009-use-prefix-include-for-inductor.patch
       - patches/0010-make-ATEN_INCLUDE_DIR-relative-to-TORCH_INSTALL_PREF.patch 
       - patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch             # [win]
+      - patches/0012-CD-Enable-Python-3.13-on-windows-138095.patch                          # [win]
       - patches_submodules/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch  # [win]
 
       # See https://github.com/pytorch/pytorch/pull/137331

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -158,7 +158,7 @@ requirements:
     - wheel
     - pyyaml
     - requests
-    - future
+    - future  # [py<313]
     - six
     - mkl-devel {{ mkl }}           # [blas_impl == "mkl"]
     - openblas-devel {{ openblas }}   # [blas_impl == "openblas"]
@@ -321,7 +321,7 @@ outputs:
         - wheel
         - pyyaml
         - requests
-        - future
+        - future  # [py<313]
         - six
         - mkl-devel {{ mkl }}           # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}   # [blas_impl == "openblas"]

--- a/recipe/patches/0012-CD-Enable-Python-3.13-on-windows-138095.patch
+++ b/recipe/patches/0012-CD-Enable-Python-3.13-on-windows-138095.patch
@@ -1,0 +1,52 @@
+From db896f927403f55a18f931b18a6469cb4e37d322 Mon Sep 17 00:00:00 2001
+From: atalman <atalman@fb.com>
+Date: Tue, 12 Nov 2024 12:28:10 +0000
+Subject: [PATCH 14/21] CD Enable Python 3.13 on windows (#138095)
+
+Adding CD windows. Part of: https://github.com/pytorch/pytorch/issues/130249
+Builder PR landed with smoke test: https://github.com/pytorch/builder/pull/2035
+
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/138095
+Approved by: https://github.com/Skylion007, https://github.com/malfet
+
+Cherry-pick-note: minus changes in `.github/*`
+---
+ functorch/csrc/dim/dim.cpp      |  1 +
+ functorch/csrc/dim/dim_opcode.c | 13 ++++++++++++-
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/functorch/csrc/dim/dim.cpp b/functorch/csrc/dim/dim.cpp
+index 722618efbb0..f98818bfdcc 100644
+--- a/functorch/csrc/dim/dim.cpp
++++ b/functorch/csrc/dim/dim.cpp
+@@ -38,6 +38,7 @@ PyObject* Dim_init() {
+ #include "python_variable_simple.h"
+ 
+ #if IS_PYTHON_3_11_PLUS
++
+ #define Py_BUILD_CORE
+ #include "internal/pycore_opcode.h"
+ #undef Py_BUILD_CORE
+diff --git a/functorch/csrc/dim/dim_opcode.c b/functorch/csrc/dim/dim_opcode.c
+index 81ba62a3781..1b5d0677344 100644
+--- a/functorch/csrc/dim/dim_opcode.c
++++ b/functorch/csrc/dim/dim_opcode.c
+@@ -1,6 +1,17 @@
+ #include <torch/csrc/utils/python_compat.h>
+ #if defined(_WIN32) && IS_PYTHON_3_11_PLUS
+ #define Py_BUILD_CORE
+-#define NEED_OPCODE_TABLES
++#define NEED_OPCODE_TABLES // To get _PyOpcode_Deopt, _PyOpcode_Caches
++
++#if IS_PYTHON_3_13_PLUS
++#include <cpython/code.h> // To get PyUnstable_Code_GetFirstFree
++#define NEED_OPCODE_METADATA
++#include "internal/pycore_opcode_metadata.h"
++#undef NEED_OPCODE_METADATA
++#else
+ #include "internal/pycore_opcode.h"
+ #endif
++
++#undef NEED_OPCODE_TABLES
++#undef Py_BUILD_CORE
++#endif


### PR DESCRIPTION
pytorch: python 3.13 support

## Changes
- Build for 3.13
- ~Temporarily remove "skip-existing" as it was causing libtorch to not get rebuilt, but in order to build pytroch we need to build libtorch first. This can be removed before merging.~
-  Adds a patch from conda-forge that fixes windows build
- `future`  is not needed for 3.13 (or possibly at all). Minimize changes for this PR. Investigate for the next release.
- ~Temporarily skip all non 3.13 builds to conserve CI resources. This will be removed before merging.~

## Notes
- The build number was not bumped. 
- Plan on only releasing the `pytorch` artifacts from here: https://staging.continuum.io/prefect/fs/pytorch-feedstock/pr60/c148f46 (Which are just 3.13)
- Excluding `libtorch`, `pytorch-cpu`, `pytorch-gpu` which already exist and don't need rebuilt. 