### PR TITLE
CI Skip 2.5.1 optimizations

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -165,8 +165,11 @@ if "%PKG_NAME%" == "libtorch" (
   
 
   if "%PY_VER%"=="%megabuild_python%" (
+    :: We previously built the wheel when building libtorch, just install that. 
     pushd %SRC_DIR%
       %PYTHON% -m pip install --find-links=mega_dist torch --no-build-isolation --no-deps
+      :: Cleanup this wheel so we don't accidentally use it again.
+      rm -rf mega_dist
     popd
   ) else (
     :: NOTE: Passing --cmake is necessary here since the torch frontend has its

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -118,6 +118,12 @@ if "%PKG_NAME%" == "libtorch" (
   :: Extract the compiled wheel into a temporary directory
   if not exist "%SRC_DIR%/dist" mkdir %SRC_DIR%/dist
   pushd %SRC_DIR%\dist
+  
+  :: Keep a copy of this wheel so we don't have to rebuild it later.
+  mkdir %SRC_DIR%\mega_dist
+  copy torch-*.whl %SRC_DIR%\mega_dist
+
+  :: Unpack the wheel
   for %%f in (torch-*.whl) do (
       wheel unpack %%f
   )
@@ -156,12 +162,19 @@ if "%PKG_NAME%" == "libtorch" (
   popd
   popd
 ) else (
-  :: NOTE: Passing --cmake is necessary here since the torch frontend has its
-  :: own cmake files that it needs to generate
-  %PYTHON% setup.py clean
-  %PYTHON% setup.py bdist_wheel --cmake
-  %PYTHON% -m pip install --find-links=dist torch --no-build-isolation --no-deps
-  if %ERRORLEVEL% neq 0 exit 1
+  
+
+  if "%PY_VER%"=="%megabuild_python%" (
+    pushd %SRC_DIR%
+      %PYTHON% -m pip install --find-links=mega_dist torch --no-build-isolation --no-deps
+    popd
+  ) else (
+    :: NOTE: Passing --cmake is necessary here since the torch frontend has its
+    :: own cmake files that it needs to generate
+    %PYTHON% setup.py bdist_wheel --cmake
+    %PYTHON% -m pip install --find-links=dist torch --no-build-isolation --no-deps
+    if %ERRORLEVEL% neq 0 exit 1
+  )
 
   :: Move libtorch_python and remove the other directories afterwards.
   robocopy /NP /NFL /NDL /NJH /E %SP_DIR%\torch\bin\ %LIBRARY_BIN%\ torch_python.dll

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -39,3 +39,7 @@ zip_keys:                    # [(osx and arm64)]
 megabuild:
 - true
 #- false     # [osx]
+
+# The version of python to use when building libtorch in a "megabuild"
+megabuild_python:
+  - 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,6 @@ build:
     - python *                               # [megabuild]
     - numpy *                                # [megabuild]
   skip: True  # [py<39]
-  skip: True  # [unix]
 
 requirements:
   # Keep this list synchronized (except for python*, numpy*) in outputs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,13 +80,14 @@ build:
     - python *                               # [megabuild]
     - numpy *                                # [megabuild]
   skip: True  # [py<39]
+  skip: True  # [unix]
 
 requirements:
   # Keep this list synchronized (except for python*, numpy*) in outputs
   # We use python to build libtorch as well because it is easier
   build:
-    # When you change 3.12 here, change it in build.sh as well
-    - python 3.12                            # [megabuild and build_platform != target_platform]
+    # When you change megabuild_python, change it in build.sh as well
+    - python {{ megabuild_python }}          # [megabuild and build_platform != target_platform]
     - python                                 # [not megabuild and build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - numpy  *                               # [megabuild and build_platform != target_platform]
@@ -150,7 +151,7 @@ requirements:
     - cuda-cupti
     {% endif %}
     # other requirements
-    - python 3.12  # [megabuild]
+    - python {{megabuild_python}}  # [megabuild]
     - python       # [not megabuild]
     - numpy 2
     - pip


### PR DESCRIPTION
Windows build optimizations

## Changes
- Set the version of python we are using for the `megabuild` in the conda_build_config.yaml
- Use this version in meta.yaml
- Stash the pytorch wheel after building libtorch
- Once it's time to build pytorch with the same version we built libtorch with, just use the previously built wheel. 

## Notes
- [Previous build](https://cloud.prefect.io/anaconda/flow-run/04721e9b-f56c-47a4-b753-495154199ca0) took 52 hours to build python variants 3.9-3.12
- [This build](https://cloud.prefect.io/anaconda/flow-run/2fbddb5d-453c-4361-b6d0-85af49ce5711?overview) took 30 hours to build 3.9-3.13
- This does not functionally change the package and does not need to be released until the next version, so the build number stays the same. 