### PR TITLE
Pkg 6002 linux cuda 2.5 skip CI

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -247,14 +247,7 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     elif [[ ${cuda_compiler_version} == 11.8 ]]; then
         export TORCH_CUDA_ARCH_LIST="3.5+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9"
         export CUDA_TOOLKIT_ROOT_DIR=$CUDA_HOME
-    elif [[ ${cuda_compiler_version} == 12.0 ]]; then
-        export TORCH_CUDA_ARCH_LIST="5.0+PTX;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0"
-        # $CUDA_HOME not set in CUDA 12.0. Using $PREFIX
-        export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
-        if [[ "${target_platform}" != "${build_platform}" ]]; then
-            export CUDA_TOOLKIT_ROOT=${PREFIX}
-        fi
-    elif [[ ${cuda_compiler_version} == 12.6 ]]; then
+    elif [[ ${cuda_compiler_version} == 12.[0-6] ]]; then
         export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
         # $CUDA_HOME not set in CUDA 12.0. Using $PREFIX
         export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -87,10 +87,14 @@ export Python3_ROOT_DIR=${PREFIX}
 export Python3_EXECUTABLE="${PYTHON}"
 
 # Uncomment to use ccache; development only
+# ccache -M 25Gi && ccache -F 0
 # export CMAKE_C_COMPILER_LAUNCHER=ccache
 # export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 # export CMAKE_CUDA_COMPILER_LAUNCHER=ccache
+# first removes the timestamp directory, second ignores directories entirely when considering cache hits.
+# Neither verified; try both.
 # export CCACHE_BASEDIR=${PREFIX}/../
+# export CCACHE_NOHASHDIR=true
 
 for ARG in $CMAKE_ARGS; do
   if [[ "$ARG" == "-DCMAKE_"* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,6 +197,9 @@ test:
     # cmake needs a compiler to run package detection, see
     # https://discourse.cmake.org/t/questions-about-find-package-cli-msvc/6194
     - {{ compiler('cxx') }}
+    # for CMake config to find cuda & nvrtc
+    - {{ compiler('cuda') }}    # [(gpu_variant or "").startswith("cuda")]
+    - cuda-nvrtc-dev            # [(gpu_variant or "").startswith("cuda")]
     - cmake
     - ninja
     - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -228,6 +228,8 @@ outputs:
         - "**/torch_cpu.dll"          # [win]
         - "**/torch_python.dll"       # [win]
         - $RPATH/ld64.so.1  # [s390x]
+        - # libcuda.so is the cuda driver API library and is a system library.
+        - "**/libcuda.so*"            # [(gpu_variant or "").startswith("cuda")]
   - name: pytorch
     build:
       string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda-12"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -377,8 +377,7 @@ outputs:
         - nomkl                 # [blas_impl != "mkl"]
         - fsspec
         # Required to support torch.compile. This is tested in smoke_test.py, which is required to pass
-        # torch.compile isn't supported on python 3.12 and we only build cuda for linux-64 at the moment
-        - torchtriton {{ '.'.join(version.split('.')[:2]) }}.*       # [(gpu_variant or "").startswith("cuda") and (linux and x86_64) and (py!=312)]
+        - triton 3.1.0       # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
         # avoid that people without GPUs needlessly download ~0.5-1GB
         # The CUDA version constraint is handled in cuda-version as a run_constrained.
         # However, that doesn't enforce that the package requires a GPU; that needs to be done here.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,8 @@ source:
       - patches/0013-simplify-torch.utils.cpp_extension.include_paths-use.patch             # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
       - patches/0014-point-include-paths-to-PREFIX-include.patch                            # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
       - patches/0015-point-lib-paths-to-PREFIX-lib.patch                                    # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
+      # https://github.com/pytorch/pytorch/pull/137140
+      - patches/0016-Fix-test_out-when-run-on-CPU-with-CUDA-available-137.patch
 
       # See https://github.com/pytorch/pytorch/pull/137331
       # for status
@@ -416,6 +418,8 @@ outputs:
         - pytest-xdist
         # Needed for test_autograd.py
         - pybind11
+        # the inductor "test_aoti_eager..." tests require objcopy
+        - binutils
       imports:
         - torch
       source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -187,6 +187,7 @@ requirements:
   run:
     - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
     - libuv  # [win]
+    - {{ pin_compatible('magma') }}                       # [(gpu_variant or "").startswith("cuda")]
 
 # these tests are for the libtorch output below, but due to
 # a particularity of conda-build, that output is defined in

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -228,7 +228,7 @@ outputs:
         - "**/torch_cpu.dll"          # [win]
         - "**/torch_python.dll"       # [win]
         - $RPATH/ld64.so.1  # [s390x]
-        - # libcuda.so is the cuda driver API library and is a system library.
+        # libcuda.so is the cuda driver API library and is a system library.
         - "**/libcuda.so*"            # [(gpu_variant or "").startswith("cuda")]
   - name: pytorch
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -478,7 +478,8 @@ outputs:
         - python -c "import numpy; import torch"
         # distributed support is enabled by default on linux; for mac, we enable it manually in build.sh
         - python -c "import torch; assert torch.distributed.is_available()"        # [linux or osx]
-        - python -c "import torch; assert torch.backends.mkldnn.m.is_available()"  # [blas_impl == "mkl"]
+        # mkldnn is set in build.sh for linux/non-cuda variants
+        - python -c "import torch; assert torch.backends.mkldnn.m.is_available()"  # [linux and not (gpu_variant or "").startswith("cuda")]
         - python -c "import torch; assert torch.backends.cuda.is_built()"          # [(gpu_variant or "").startswith("cuda")]
         - python -c "import torch; assert torch.backends.cudnn.is_available()"     # [(gpu_variant or "").startswith("cuda")]
         - python -c "import torch; assert torch.cuda.is_available()"               # [(gpu_variant or "").startswith("cuda")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,11 @@ source:
       - patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch             # [win]
       - patches/0012-CD-Enable-Python-3.13-on-windows-138095.patch                          # [win]
       - patches_submodules/0001-remove-DESTINATION-lib-from-CMake-install-directives.patch  # [win]
+      # These patches have only been tested on linux/cuda, but should solve problems on other platforms.
+      # test on other plats before applying there to make sure they solve rather than cause problems.
+      - patches/0013-simplify-torch.utils.cpp_extension.include_paths-use.patch             # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
+      - patches/0014-point-include-paths-to-PREFIX-include.patch                            # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
+      - patches/0015-point-lib-paths-to-PREFIX-lib.patch                                    # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
 
       # See https://github.com/pytorch/pytorch/pull/137331
       # for status

--- a/recipe/patches/0013-simplify-torch.utils.cpp_extension.include_paths-use.patch
+++ b/recipe/patches/0013-simplify-torch.utils.cpp_extension.include_paths-use.patch
@@ -1,0 +1,50 @@
+From 12a4473ae7a47da2a30121f329a2c3c8f3f456c5 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 23 Jan 2025 22:46:58 +1100
+Subject: [PATCH 09/15] simplify torch.utils.cpp_extension.include_paths; use
+ it in cpp_builder
+
+The /TH headers have not existed since pytorch 1.11
+---
+ torch/_inductor/cpp_builder.py | 13 +++----------
+ torch/utils/cpp_extension.py   |  4 ----
+ 2 files changed, 3 insertions(+), 14 deletions(-)
+
+Index: pytorch/torch/_inductor/cpp_builder.py
+===================================================================
+--- pytorch.orig/torch/_inductor/cpp_builder.py	2025-03-06 16:00:42.392955757 -0600
++++ pytorch/torch/_inductor/cpp_builder.py	2025-03-06 16:00:42.456841659 -0600
+@@ -743,16 +743,9 @@
+ def _get_torch_related_args(
+     include_pytorch: bool, aot_mode: bool
+ ) -> Tuple[List[str], List[str], List[str]]:
+-    from torch.utils.cpp_extension import _TORCH_PATH, TORCH_LIB_PATH
++    from torch.utils.cpp_extension import include_paths, TORCH_LIB_PATH
+ 
+-    include_dirs = [
+-        os.path.join(_TORCH_PATH, "include"),
+-        os.path.join(_TORCH_PATH, "include", "torch", "csrc", "api", "include"),
+-        # Some internal (old) Torch headers don't properly prefix their includes,
+-        # so we need to pass -Itorch/lib/include/TH as well.
+-        os.path.join(_TORCH_PATH, "include", "TH"),
+-        os.path.join(_TORCH_PATH, "include", "THC"),
+-    ]
++    include_dirs = include_paths()
+     libraries_dirs = [TORCH_LIB_PATH]
+     libraries = []
+     if sys.platform != "darwin" and not config.is_fbcode():
+Index: pytorch/torch/utils/cpp_extension.py
+===================================================================
+--- pytorch.orig/torch/utils/cpp_extension.py	2024-12-16 15:07:01.482833535 -0600
++++ pytorch/torch/utils/cpp_extension.py	2025-03-06 16:01:11.398235000 -0600
+@@ -1159,10 +1159,6 @@
+         lib_include,
+         # Remove this once torch/torch.h is officially no longer supported for C++ extensions.
+         os.path.join(lib_include, 'torch', 'csrc', 'api', 'include'),
+-        # Some internal (old) Torch headers don't properly prefix their includes,
+-        # so we need to pass -Itorch/lib/include/TH as well.
+-        os.path.join(lib_include, 'TH'),
+-        os.path.join(lib_include, 'THC')
+     ]
+     if cuda and IS_HIP_EXTENSION:
+         paths.append(os.path.join(lib_include, 'THH'))

--- a/recipe/patches/0014-point-include-paths-to-PREFIX-include.patch
+++ b/recipe/patches/0014-point-include-paths-to-PREFIX-include.patch
@@ -1,0 +1,42 @@
+From 2e9805edf7c26bf7890a8704460047592fff3a79 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 23 Jan 2025 22:58:14 +1100
+Subject: [PATCH 10/15] point include paths to $PREFIX/include
+
+---
+ torch/utils/cpp_extension.py | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+Index: pytorch/torch/utils/cpp_extension.py
+===================================================================
+--- pytorch.orig/torch/utils/cpp_extension.py	2025-03-06 16:00:42.457678160 -0600
++++ pytorch/torch/utils/cpp_extension.py	2025-03-06 16:00:42.489486590 -0600
+@@ -1155,10 +1155,28 @@
+         A list of include path strings.
+     """
+     lib_include = os.path.join(_TORCH_PATH, 'include')
++    if (os.environ.get("CONDA_BUILD", None) is not None
++            and os.environ.get("CONDA_BUILD_CROSS_COMPILATION", None) not in (None, "", "0")):
++        # to avoid problems in cross-compilation, we need to point to the same environment
++        # where the currently running pytorch is -- i.e. the BUILD_PREFIX. See
++        # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/349
++        pieces = [os.environ["BUILD_PREFIX"]] + IS_WINDOWS * ["Library"] + ["include"]
++        lib_include = os.path.join(*pieces)
++    elif os.environ.get("CONDA_BUILD", None) is not None:
++        # regular build (& testing) phase --> PREFIX is set
++        pieces = [os.environ["PREFIX"]] + IS_WINDOWS * ["Library"] + ["include"]
++        lib_include = os.path.join(*pieces)
++    elif os.environ.get("CONDA_PREFIX", None) is not None:
++        # final environment
++        pieces = [os.environ["CONDA_PREFIX"]] + IS_WINDOWS * ["Library"] + ["include"]
++        lib_include = os.path.join(*pieces)
+     paths = [
+         lib_include,
+         # Remove this once torch/torch.h is officially no longer supported for C++ extensions.
+         os.path.join(lib_include, 'torch', 'csrc', 'api', 'include'),
++        # add site-packages/torch/include again (`lib_include` may have been pointing to
++        # $PREFIX/include), as some torch-internal headers are still in this directory
++        os.path.join(_TORCH_PATH, 'include'),
+     ]
+     if cuda and IS_HIP_EXTENSION:
+         paths.append(os.path.join(lib_include, 'THH'))

--- a/recipe/patches/0015-point-lib-paths-to-PREFIX-lib.patch
+++ b/recipe/patches/0015-point-lib-paths-to-PREFIX-lib.patch
@@ -1,0 +1,32 @@
+From: "danpetry" <dpetry@anaconda.com>
+Date: Thu, 6 Mar 2025
+Subject: Point lib paths to $PREFIX/lib
+
+Point cpp_extension, which is used in cpp_builder to compile at runtime,
+towards the lib directory rather than the site-packages directory, because
+that's where are sos/dlls are.
+
+Index: pytorch/torch/utils/cpp_extension.py
+===================================================================
+--- pytorch.orig/torch/utils/cpp_extension.py	2025-03-06 16:01:26.600202667 -0600
++++ pytorch/torch/utils/cpp_extension.py	2025-03-06 16:02:39.676025365 -0600
+@@ -38,7 +38,18 @@
+ 
+ _HERE = os.path.abspath(__file__)
+ _TORCH_PATH = os.path.dirname(os.path.dirname(_HERE))
+-TORCH_LIB_PATH = os.path.join(_TORCH_PATH, 'lib')
++if os.environ.get("CONDA_BUILD", None) is not None:
++    # regular build (& testing) phase --> PREFIX is set
++    # linux: PREFIX + lib
++    # windows: PREFIX + Library/bin/
++    pieces = [os.environ["PREFIX"]] + ["Library/bin" if IS_WINDOWS else "lib"]
++    TORCH_LIB_PATH = os.path.join(*pieces)
++elif os.environ.get("CONDA_PREFIX", None) is not None:
++    # final environment
++    pieces = [os.environ["CONDA_PREFIX"]] + ["Library/bin" if IS_WINDOWS else "lib"]
++    TORCH_LIB_PATH = os.path.join(*pieces)
++else:
++    TORCH_LIB_PATH = os.path.join(_TORCH_PATH, 'lib')
+ 
+ 
+ SUBPROCESS_DECODE_ARGS = ('oem',) if IS_WINDOWS else ()

--- a/recipe/patches/0016-Fix-test_out-when-run-on-CPU-with-CUDA-available-137.patch
+++ b/recipe/patches/0016-Fix-test_out-when-run-on-CPU-with-CUDA-available-137.patch
@@ -1,0 +1,43 @@
+From 740d1eb0306f1f9d0ce81ea81f287a6b52738fab Mon Sep 17 00:00:00 2001
+From: Jake Harmon <jakeharmon@google.com>
+Date: Thu, 21 Nov 2024 23:10:04 +0000
+Subject: [PATCH] Fix test_out when run on CPU with CUDA available (#137140)
+
+Ever since #135140, this test will fail if run with CPU parameterization (e.g. test_out__refs_logical_or_cpu_float32) and CUDA available - as far as I can tell, the PyTorch CI isn't currently checking for this.
+
+Pull Request resolved: https://github.com/pytorch/pytorch/pull/137140
+Approved by: https://github.com/ezyang
+---
+ test/test_ops.py | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/test/test_ops.py b/test/test_ops.py
+index 1aee4b30678..c62c56b56d7 100644
+--- a/test/test_ops.py
++++ b/test/test_ops.py
+@@ -1082,17 +1082,15 @@ class TestCommon(TestCase):
+                     )
+ 
+             # Case 3: out= with correct shape and dtype, but wrong device.
+-            wrong_device = None
+-            if torch.device(device).type != "cpu":
+-                wrong_device = "cpu"
+-            elif torch.cuda.is_available():
+-                wrong_device = "cuda"
+-
++            #   Expected behavior: throws an error.
++            #   This case is ignored on CPU to allow some scalar operations to succeed.
+             factory_fn_msg = (
+                 "\n\nNOTE: If your op is a factory function (i.e., it accepts TensorOptions) you should mark its "
+                 "OpInfo with `is_factory_function=True`."
+             )
+-            if wrong_device is not None:
++
++            if torch.device(device).type != "cpu":
++                wrong_device = "cpu"
+ 
+                 def _case_three_transform(t):
+                     return make_tensor(t.shape, dtype=t.dtype, device=wrong_device)
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6002](https://anaconda.atlassian.net/browse/PKG-6002) 
- [Upstream repository](https://github.com/pytorch/pytorch/tree/v2.5.1)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/mlir-feedstock/pull/4
  - https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/21
  - https://github.com/AnacondaRecipes/triton-feedstock/pull/3
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/247

### Explanation of changes:

- NB this is needed for the end of the week - please be reactive and consider whether nonfunctional changes can wait till future PRs
- The dev instance with the logfiles unfortunately died but a build is being re-run - logs to follow
- Built against sysroot v2.28 in [this channel](https://anaconda.org/cuda12_def) and in a docker container based on rocky 8, defined [here](https://github.com/anaconda/docker-images/blob/cuda-rocky8/anaconda-pkg-build/linux/cuda-rocky8/Dockerfile). This is because of the compatibility issues addressed in the repodata hotfix PR above
- cover cuda 12.0-6 in the gpu architecture configuration section
- add four patches to fix tests
- add dependencies required for run and tests
- add back in a whitelist entry that seems to have been dropped
- add triton, required at runtime; and binutils, required at test time
- align the mkldnn availability test with the configuration in build.sh


[PKG-6002]: https://anaconda.atlassian.net/browse/PKG-6002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ