### PR TITLE
CI Skip Ensure CUDA uses system NVTX 

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -269,6 +269,7 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     export USE_SYSTEM_NCCL=1
     export USE_STATIC_NCCL=0
     export USE_STATIC_CUDNN=0
+    export USE_SYSTEM_NVTX=1
     export MAGMA_HOME="${PREFIX}"
     export CUDA_INC_PATH="${PREFIX}/targets/x86_64-linux/include/"  # Point cmake to the header files
 else

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 gpu_variant:
   - cpu
-  #- metal                    # [(osx and arm64)]
-  #- cuda-12                  # [(linux and x86_64)]
+  - metal                    # [(osx and arm64)]
+  - cuda-12                  # [(linux and x86_64)]
 c_compiler_version:      # [osx]
   - 17                   # [osx]
 cxx_compiler_version:    # [osx]


### PR DESCRIPTION
Pytorch 2.6.0

**Destination channel:** defaults

### Links

- [PKG-8724](https://anaconda.atlassian.net/browse/PKG-8724) 
- [Upstream repository](https://github.com/pytorch/pytorch/)
- [Upstream changelog/diff](https://github.com/pytorch/pytorch/releases/tag/v2.6.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- Change USE_SYSTEM_NVTX to be used on CUDA 


[PKG-8724]: https://anaconda.atlassian.net/browse/PKG-8724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ