### PR TITLE
PKG-14084: remove pytorch-cpu/gpu from anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -9,5 +9,3 @@ upstream_sources:
     packages:
       - libtorch
       - pytorch
-      - pytorch-cpu
-      - pytorch-gpu


### PR DESCRIPTION
## Summary
Remove `pytorch-cpu` and `pytorch-gpu` from `upstream_sources.packages` (DDB Group 3 alignment).

## Ticket
PKG-14084

Made with [Cursor](https://cursor.com)