### PR TITLE
Try to force linking with intel-openmp for mkl builds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -7,6 +7,3 @@ task_timeout: 72000
 
 # build_parameters:
 #  - "--no-test"
-
-channels:
-  - https://staging.continuum.io/pbp/fs/sleef-feedstock/pr4/ec3fc0d

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,3 +7,6 @@ task_timeout: 72000
 
 # build_parameters:
 #  - "--no-test"
+
+channels:
+  - https://staging.continuum.io/pbp/fs/sleef-feedstock/pr4/ec3fc0d

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -17,6 +17,7 @@ python build-locally.py
 
 The following script may help build all cuda version sequentially:
 ```bash
+
 #!/usr/env/bin bash
 
 set -ex

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -167,7 +167,11 @@ elif [[ "$target_platform" == "linux-64" && ${gpu_variant} == "cuda"* ]]; then
     # cicc OOMs on fbgemm_genai CUTLASS templates on runners. Rather
     # than globally throttle, we serialize only fbgemm_genai via a Ninja job
     # pool (patch 0024 + CMAKE_JOB_POOLS below) and leave MAX_JOBS high.
-    export MAX_JOBS=$((CPU_COUNT > 1 ? CPU_COUNT - 1 : 1))
+    if [[ ${cuda_compiler_version} == 13.* ]]; then
+        export MAX_JOBS=6
+    else
+        export MAX_JOBS=$((CPU_COUNT > 1 ? CPU_COUNT - 1 : 1))
+    fi
 else
     # Leave a spare core for other tasks. This may need to be reduced further
     # if we get out of memory errors. (Each job uses a certain amount of memory.)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,7 @@ gpu_variant:
   - cpu
   - metal                    # [(osx and arm64)]
   - cuda                     # [win or linux]
+  - cuda                     # [win or (linux and x86_64)]
 
 # Linux aarch64 needs gcc 15.2.0 due to a bug with 14.3 with vector instructions
 c_compiler_version:          # [linux and aarch64]
@@ -13,12 +14,13 @@ c_compiler_version:          # [linux and x86_64]
   - 14                       # [linux and x86_64]
 cxx_compiler_version:        # [linux and x86_64]
   - 14                       # [linux and x86_64]
-cuda_compiler_version:       # [win or (linux and x86_64)]
-  - 12.9                     # [win or (linux and x86_64)]
-  - 13.0                     # [win or (linux and x86_64)]
+
 # aarch64 only supports CUDA 13.x (CUDA 12.x requires gcc <15, but aarch64 needs gcc 15.2.0)
-cuda_compiler_version:       # [linux and aarch64]
-  - 13.0                     # [linux and aarch64]
+cuda_compiler_version:       # [win or linux]
+  - None                     # [win or linux]
+  - 12.9                     # [win or (linux and x86_64)]
+  - 13.0                     # [win or linux]
+
 # CONDA_BUILD_SYSROOT is defined in the base cbc.yaml, but it's reflected here so we can zip the keys and
 # build GPU and CPU at the same time for osx-arm64. It'll need to be manually updated here if the base cbc is changed.
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.
@@ -29,10 +31,11 @@ MACOSX_SDK_VERSION:          # [(osx and arm64)]
 CONDA_BUILD_SYSROOT:         # [(osx and arm64)]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [(osx and arm64)]
-zip_keys:                    # [(osx and arm64)]
-  - gpu_variant              # [(osx and arm64)]
+zip_keys:
+  - gpu_variant
   - MACOSX_SDK_VERSION       # [(osx and arm64)]
   - CONDA_BUILD_SYSROOT      # [(osx and arm64)]
+  - cuda_compiler_version    # [win or linux]
 # megabuild is disabled as our CI runners work on each python version separately.
 megabuild:
 - false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set sha256 = "ab3fde9e7e382f45ac942be6ea2c2ef362c5ccd6f55ed6d5f35e6ea81d3ab88e" %}
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 
 # Keep this in sync with the release
@@ -69,6 +69,7 @@ source:
   - url: https://raw.githubusercontent.com/pytorch/pytorch/refs/tags/v{{ version }}/.gitignore
 
 build:
+  skip: true  # [not (win and x86_64 and gpu_variant == "cpu" and blas_impl == "mkl")]
   number: {{ build }}
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
@@ -222,6 +223,8 @@ test:
     - cd cmake_test
     - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]
     - cmake -GNinja -DCMAKE_CXX_STANDARD=17 %CMAKE_ARGS% .  # [win]
+    - dumpbin /dependents "%PREFIX%\Library\bin\dnnl.dll" | findstr /i libiomp5md  # [win and blas_impl == "mkl"]
+    - dumpbin /dependents "%PREFIX%\Library\bin\dnnl.dll" | findstr /i vcomp && exit /b 1 || exit /b 0  # [win and blas_impl == "mkl"]
 
 outputs:
   - name: libtorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,6 @@ source:
 
 build:
   skip: true  # [not (gpu_variant == "cpu" and blas_impl == "mkl")]
-  skip: true  # [py!=312]
   number: {{ build }}
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,6 @@ source:
 
 build:
   skip: true  # [not (gpu_variant == "cpu" and blas_impl == "mkl")]
-  skip: true  # [not linux]
   skip: true  # [py!=312]
   number: {{ build }}
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ source:
   - url: https://raw.githubusercontent.com/pytorch/pytorch/refs/tags/v{{ version }}/.gitignore
 
 build:
-  skip: true  # [not (win and x86_64 and gpu_variant == "cpu" and blas_impl == "mkl")]
+  skip: true  # [not (gpu_variant == "cpu" and blas_impl == "mkl")]
   number: {{ build }}
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -189,6 +189,7 @@ requirements:
     - fmt {{ fmt }}
   # satisfy overlinking checks
   run:
+    - libgomp                                # [linux and blas_impl != "mkl"]
     - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
     - libuv                                  # [win]
     - {{ pin_compatible('magma') }}          # [(gpu_variant or "").startswith("cuda")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -379,8 +379,7 @@ outputs:
         - python
         - numpy >=1.24.0,<3.0.0
         - typing_extensions >=4.10.0
-        # To stop the compiler pulling in an openmp implementation itself (although I'm not sure this mutex works anyway)
-        - _openmp_mutex                                       # [linux]
+        - libgomp  # [linux and blas_impl == "openblas"]
         - {{ pin_compatible('magma') }}                       # [(gpu_variant or "").startswith("cuda")]
         # skip to 1.13.3 to avoid test failures on Windows and mac - align with 2.7.0 release requirement
         # https://github.com/pytorch/pytorch/pull/133235

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -170,8 +170,9 @@ requirements:
     # We pull in the same versions of mkl and intel-openmp: intel aligns the versions
     # We use intel-openmp for all mkl variants.
     # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
-    - intel-openmp {{ mkl }}         # [blas_impl == "mkl"]
+    - intel-openmp {{ mkl }}      # [blas_impl == "mkl"]
     - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
+    - libgomp                     # [linux and blas_impl != "mkl"]
     - libabseil {{ libabseil }}
     - libprotobuf {{ libprotobuf }}
     - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
@@ -358,6 +359,7 @@ outputs:
         # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
         - intel-openmp {{ mkl }}      # [blas_impl == "mkl"]
         - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
+        - libgomp                     # [linux and blas_impl != "mkl"]
         - libabseil
         - libprotobuf {{ libprotobuf }}
         - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,6 @@ source:
   - url: https://raw.githubusercontent.com/pytorch/pytorch/refs/tags/v{{ version }}/.gitignore
 
 build:
-  skip: true  # [not (gpu_variant == "cpu" and blas_impl == "mkl")]
   number: {{ build }}
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,7 +117,7 @@ requirements:
     - libcusparse-dev                        # [build_platform != target_platform]
     {% endif %}
     - git       # [not win]
-    - libgomp   # [linux]
+    - libgomp   # [linux and blas_impl != "mkl"]
     # This has a strong run_export so we don't need to put it in `host` or `run`
     # We use llvm-openmp for openblas variants on osx.
     - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
@@ -175,7 +175,9 @@ requirements:
     - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
     - libabseil {{ libabseil }}
     - libprotobuf {{ libprotobuf }}
-    - sleef 3.5.1
+    - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
+    - sleef 3.9.0 *llvm_openmp*   # [osx]
+    - sleef 3.9.0 *no_openmp*     # [win or blas_impl == "mkl"]
     - libuv
     - pkg-config  # [unix]
     - typing_extensions
@@ -303,7 +305,7 @@ outputs:
         - libcusparse-dev                        # [build_platform != target_platform]
         {% endif %}
         - git       # [not win]
-        - libgomp   # [linux]
+        - libgomp   # [linux and blas_impl != "mkl"]
         # This has a strong run_export so we don't need to put it in `host` or `run`
         # We use llvm-openmp for openblas variants on osx.
         - llvm-openmp 17             # [osx and not (blas_impl == "mkl")]
@@ -359,7 +361,9 @@ outputs:
         - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
         - libabseil
         - libprotobuf {{ libprotobuf }}
-        - sleef 3.5.1
+        - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
+        - sleef 3.9.0 *llvm_openmp*   # [osx]
+        - sleef 3.9.0 *no_openmp*     # [win or blas_impl == "mkl"]
         - libuv
         - pkg-config  # [unix]
         - typing_extensions
@@ -379,7 +383,7 @@ outputs:
         - python
         - numpy >=1.24.0,<3.0.0
         - typing_extensions >=4.10.0
-        - libgomp  # [linux and blas_impl == "openblas"]
+        - libgomp  # [linux and blas_impl != "mkl"]
         - {{ pin_compatible('magma') }}                       # [(gpu_variant or "").startswith("cuda")]
         # skip to 1.13.3 to avoid test failures on Windows and mac - align with 2.7.0 release requirement
         # https://github.com/pytorch/pytorch/pull/133235

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,8 @@ source:
 
 build:
   skip: true  # [not (gpu_variant == "cpu" and blas_impl == "mkl")]
+  skip: true  # [not linux]
+  skip: true  # [py!=312]
   number: {{ build }}
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -119,7 +119,7 @@ requirements:
     - libgomp   # [linux and blas_impl != "mkl"]
     # This has a strong run_export so we don't need to put it in `host` or `run`
     # We use llvm-openmp for openblas variants on osx.
-    - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
+    - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
     - libuv     # [win]
     - cmake
     - ninja-base
@@ -171,7 +171,7 @@ requirements:
     # We use intel-openmp for all mkl variants.
     # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
     - intel-openmp {{ mkl }}         # [blas_impl == "mkl"]
-    - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
+    - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
     - libabseil {{ libabseil }}
     - libprotobuf {{ libprotobuf }}
     - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
@@ -307,7 +307,7 @@ outputs:
         - libgomp   # [linux and blas_impl != "mkl"]
         # This has a strong run_export so we don't need to put it in `host` or `run`
         # We use llvm-openmp for openblas variants on osx.
-        - llvm-openmp 17             # [osx and not (blas_impl == "mkl")]
+        - llvm-openmp                # [osx and not (blas_impl == "mkl")]
         - cmake
         - ninja-base
         # Keep libprotobuf here so that a compatibile version
@@ -357,7 +357,7 @@ outputs:
         # We use intel-openmp for all mkl variants.
         # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
         - intel-openmp {{ mkl }}      # [blas_impl == "mkl"]
-        - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
+        - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
         - libabseil
         - libprotobuf {{ libprotobuf }}
         - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,14 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake | 69 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 61 insertions(+), 8 deletions(-)
+ cmake/Dependencies.cmake | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 70 insertions(+), 8 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,67 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,76 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -32,6 +32,15 @@ index ef5c2fd4e97..4696cdd4505 100644
 +      # introducing a second OpenMP runtime through bundled oneDNN.
 +      set(DNNL_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
 +      set(ONEDNN_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
++      # oneDNN still probes OpenMP for `#pragma omp simd` even with the SEQ
++      # runtime. Use GCC's SIMD-only flag so the dnnl shared library does not
++      # inherit a libgomp dependency from `-fopenmp`.
++      set(OpenMP_C_FLAGS "-fopenmp-simd" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_FLAGS "-fopenmp-simd" CACHE STRING "" FORCE)
++      set(OpenMP_C_LIB_NAMES "" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_LIB_NAMES "" CACHE STRING "" FORCE)
++      set(OpenMP_C_LIBRARIES "" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_LIBRARIES "" CACHE STRING "" FORCE)
 +      foreach(_flag_var
 +              CMAKE_C_FLAGS CMAKE_CXX_FLAGS
 +              CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,14 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------
- 1 file changed, 70 insertions(+), 8 deletions(-)
+ cmake/Dependencies.cmake | 90 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 82 insertions(+), 8 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,76 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,88 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -35,6 +35,12 @@ index ef5c2fd4e97..4696cdd4505 100644
 +      # oneDNN still probes OpenMP for `#pragma omp simd` even with the SEQ
 +      # runtime. Use GCC's SIMD-only flag so the dnnl shared library does not
 +      # inherit a libgomp dependency from `-fopenmp`.
++      foreach(_openmp_var
++              OpenMP_C_FLAGS OpenMP_CXX_FLAGS
++              OpenMP_C_LIB_NAMES OpenMP_CXX_LIB_NAMES
++              OpenMP_C_LIBRARIES OpenMP_CXX_LIBRARIES)
++        set(_ANACONDA_SAVED_${_openmp_var} "${${_openmp_var}}")
++      endforeach()
 +      set(OpenMP_C_FLAGS "-fopenmp-simd" CACHE STRING "" FORCE)
 +      set(OpenMP_CXX_FLAGS "-fopenmp-simd" CACHE STRING "" FORCE)
 +      set(OpenMP_C_LIB_NAMES "" CACHE STRING "" FORCE)
@@ -55,6 +61,12 @@ index ef5c2fd4e97..4696cdd4505 100644
 +              CMAKE_C_FLAGS CMAKE_CXX_FLAGS
 +              CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
 +        set(${_flag_var} "${_ANACONDA_SAVED_${_flag_var}}")
++      endforeach()
++      foreach(_openmp_var
++              OpenMP_C_FLAGS OpenMP_CXX_FLAGS
++              OpenMP_C_LIB_NAMES OpenMP_CXX_LIB_NAMES
++              OpenMP_C_LIBRARIES OpenMP_CXX_LIBRARIES)
++        set(${_openmp_var} "${_ANACONDA_SAVED_${_openmp_var}}" CACHE STRING "" FORCE)
 +      endforeach()
 +      if(TARGET dnnl)
 +        get_target_property(_dnnl_compile_options dnnl COMPILE_OPTIONS)

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,15 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake | 90 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------
- 1 file changed, 82 insertions(+), 8 deletions(-)
+ cmake/Dependencies.cmake                         | 49 +++++++++++++++++++-----
+ third_party/ideep/mkl-dnn/cmake/OpenMP.cmake     | 19 ++++++++--
+ 2 files changed, 61 insertions(+), 15 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,88 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,49 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -28,63 +29,24 @@ index ef5c2fd4e97..4696cdd4505 100644
 +    set(MKLDNN_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 +    set(DNNL_EXPERIMENTAL_UKERNEL ON CACHE BOOL "" FORCE)
 +    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
-+      # GCC's OpenMP runtime is libgomp. MKL builds use intel-openmp, so avoid
-+      # introducing a second OpenMP runtime through bundled oneDNN.
-+      set(DNNL_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
-+      set(ONEDNN_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
-+      # oneDNN still probes OpenMP for `#pragma omp simd` even with the SEQ
-+      # runtime. Use GCC's SIMD-only flag so the dnnl shared library does not
-+      # inherit a libgomp dependency from `-fopenmp`.
-+      foreach(_openmp_var
-+              OpenMP_C_FLAGS OpenMP_CXX_FLAGS
-+              OpenMP_C_LIB_NAMES OpenMP_CXX_LIB_NAMES
-+              OpenMP_C_LIBRARIES OpenMP_CXX_LIBRARIES)
-+        set(_ANACONDA_SAVED_${_openmp_var} "${${_openmp_var}}")
-+      endforeach()
-+      set(OpenMP_C_FLAGS "-fopenmp-simd" CACHE STRING "" FORCE)
-+      set(OpenMP_CXX_FLAGS "-fopenmp-simd" CACHE STRING "" FORCE)
-+      set(OpenMP_C_LIB_NAMES "" CACHE STRING "" FORCE)
-+      set(OpenMP_CXX_LIB_NAMES "" CACHE STRING "" FORCE)
-+      set(OpenMP_C_LIBRARIES "" CACHE STRING "" FORCE)
-+      set(OpenMP_CXX_LIBRARIES "" CACHE STRING "" FORCE)
-+      foreach(_flag_var
-+              CMAKE_C_FLAGS CMAKE_CXX_FLAGS
-+              CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
-+        set(_ANACONDA_SAVED_${_flag_var} "${${_flag_var}}")
-+        string(REPLACE "-fopenmp" "" ${_flag_var} "${${_flag_var}}")
-+      endforeach()
++      find_library(ANACONDA_INTEL_OPENMP_LIBRARY NAMES iomp5 libiomp5 REQUIRED)
++      # Keep oneDNN fully OpenMP-enabled for MKL builds, but route GCC builds
++      # to Intel OpenMP. oneDNN's OpenMP.cmake is patched below so -fopenmp is
++      # compile-only; otherwise GCC injects -lgomp during libdnnl.so linking.
++      set(DNNL_CPU_RUNTIME OMP CACHE STRING "" FORCE)
++      set(ONEDNN_CPU_RUNTIME OMP CACHE STRING "" FORCE)
++      set(OpenMP_C_FLAGS "-fopenmp" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_FLAGS "-fopenmp" CACHE STRING "" FORCE)
++      set(OpenMP_C_LIB_NAMES iomp5 CACHE STRING "" FORCE)
++      set(OpenMP_CXX_LIB_NAMES iomp5 CACHE STRING "" FORCE)
++      set(OpenMP_iomp5_LIBRARY "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE FILEPATH "" FORCE)
++      set(OpenMP_C_LIBRARIES "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_LIBRARIES "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE STRING "" FORCE)
 +    endif()
 +    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn)
 +
-+    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
-+      foreach(_flag_var
-+              CMAKE_C_FLAGS CMAKE_CXX_FLAGS
-+              CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
-+        set(${_flag_var} "${_ANACONDA_SAVED_${_flag_var}}")
-+      endforeach()
-+      foreach(_openmp_var
-+              OpenMP_C_FLAGS OpenMP_CXX_FLAGS
-+              OpenMP_C_LIB_NAMES OpenMP_CXX_LIB_NAMES
-+              OpenMP_C_LIBRARIES OpenMP_CXX_LIBRARIES)
-+        set(${_openmp_var} "${_ANACONDA_SAVED_${_openmp_var}}" CACHE STRING "" FORCE)
-+      endforeach()
-+      if(TARGET dnnl)
-+        get_target_property(_dnnl_compile_options dnnl COMPILE_OPTIONS)
-+        if(_dnnl_compile_options)
-+          list(REMOVE_ITEM _dnnl_compile_options "-fopenmp")
-+          set_target_properties(dnnl PROPERTIES COMPILE_OPTIONS "${_dnnl_compile_options}")
-+        endif()
-+        get_target_property(_dnnl_link_options dnnl LINK_OPTIONS)
-+        if(_dnnl_link_options)
-+          list(REMOVE_ITEM _dnnl_link_options "-fopenmp")
-+          set_target_properties(dnnl PROPERTIES LINK_OPTIONS "${_dnnl_link_options}")
-+        endif()
-+        get_target_property(_dnnl_link_libraries dnnl LINK_LIBRARIES)
-+        if(_dnnl_link_libraries)
-+          list(REMOVE_ITEM _dnnl_link_libraries OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
-+          set_target_properties(dnnl PROPERTIES LINK_LIBRARIES "${_dnnl_link_libraries}")
-+        endif()
-+      endif()
++    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)
++      target_link_libraries(dnnl PRIVATE "${ANACONDA_INTEL_OPENMP_LIBRARY}")
 +    endif()
 +
 +    if(MSVC AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)
@@ -108,6 +70,42 @@ index ef5c2fd4e97..4696cdd4505 100644
    else()
      message("disabling MKLDNN because USE_MKLDNN is not set")
    endif()
+diff --git a/third_party/ideep/mkl-dnn/cmake/OpenMP.cmake b/third_party/ideep/mkl-dnn/cmake/OpenMP.cmake
+index ebd4a18f321..1c3e7f4a2d1 100644
+--- a/third_party/ideep/mkl-dnn/cmake/OpenMP.cmake
++++ b/third_party/ideep/mkl-dnn/cmake/OpenMP.cmake
+@@ -58,13 +58,24 @@ if(NOT OpenMP_CXX_FOUND AND MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "(Clang|Inte
+     set(OpenMP_CXX_FOUND true)
+ endif()
+ 
+-# add flags unconditionally to always utilize openmp-simd for any threading runtime
+-if(OpenMP_C_FOUND)
+-    append(CMAKE_C_FLAGS ${OpenMP_C_FLAGS})
+-endif()
+-
+-if(OpenMP_CXX_FOUND)
+-    append(CMAKE_CXX_FLAGS ${OpenMP_CXX_FLAGS})
++if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
++    # Add OpenMP flags as compile-only options for conda MKL builds. Appending
++    # -fopenmp to CMAKE_*_FLAGS makes CMake pass it to the shared-library link
++    # command too, and GCC injects -lgomp. We link libiomp5 explicitly instead.
++    if(OpenMP_C_FOUND)
++        add_compile_options($<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>)
++    endif()
++    if(OpenMP_CXX_FOUND)
++        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
++    endif()
++else()
++    # add flags unconditionally to always utilize openmp-simd for any threading runtime
++    if(OpenMP_C_FOUND)
++        append(CMAKE_C_FLAGS ${OpenMP_C_FLAGS})
++    endif()
++    if(OpenMP_CXX_FOUND)
++        append(CMAKE_CXX_FLAGS ${OpenMP_CXX_FLAGS})
++    endif()
+ endif()
+ 
+ if(DNNL_CPU_THREADING_RUNTIME MATCHES "OMP")
 -- 
 2.50.1 (Apple Git-155)
 

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,14 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake | 38 ++++++++++++++++++++++++++++++--------
- 1 file changed, 30 insertions(+), 8 deletions(-)
+ cmake/Dependencies.cmake | 69 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 61 insertions(+), 8 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,36 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,67 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -32,8 +32,39 @@ index ef5c2fd4e97..4696cdd4505 100644
 +      # introducing a second OpenMP runtime through bundled oneDNN.
 +      set(DNNL_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
 +      set(ONEDNN_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
++      foreach(_flag_var
++              CMAKE_C_FLAGS CMAKE_CXX_FLAGS
++              CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
++        set(_ANACONDA_SAVED_${_flag_var} "${${_flag_var}}")
++        string(REPLACE "-fopenmp" "" ${_flag_var} "${${_flag_var}}")
++      endforeach()
 +    endif()
 +    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn)
++
++    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
++      foreach(_flag_var
++              CMAKE_C_FLAGS CMAKE_CXX_FLAGS
++              CMAKE_SHARED_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
++        set(${_flag_var} "${_ANACONDA_SAVED_${_flag_var}}")
++      endforeach()
++      if(TARGET dnnl)
++        get_target_property(_dnnl_compile_options dnnl COMPILE_OPTIONS)
++        if(_dnnl_compile_options)
++          list(REMOVE_ITEM _dnnl_compile_options "-fopenmp")
++          set_target_properties(dnnl PROPERTIES COMPILE_OPTIONS "${_dnnl_compile_options}")
++        endif()
++        get_target_property(_dnnl_link_options dnnl LINK_OPTIONS)
++        if(_dnnl_link_options)
++          list(REMOVE_ITEM _dnnl_link_options "-fopenmp")
++          set_target_properties(dnnl PROPERTIES LINK_OPTIONS "${_dnnl_link_options}")
++        endif()
++        get_target_property(_dnnl_link_libraries dnnl LINK_LIBRARIES)
++        if(_dnnl_link_libraries)
++          list(REMOVE_ITEM _dnnl_link_libraries OpenMP::OpenMP_CXX)
++          set_target_properties(dnnl PROPERTIES LINK_LIBRARIES "${_dnnl_link_libraries}")
++        endif()
++      endif()
++    endif()
 +
 +    if(MSVC AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)
 +      find_library(ANACONDA_INTEL_OPENMP_LIBRARY NAMES libiomp5md REQUIRED)

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -69,7 +69,7 @@ index ef5c2fd4e97..4696cdd4505 100644
 +        endif()
 +        get_target_property(_dnnl_link_libraries dnnl LINK_LIBRARIES)
 +        if(_dnnl_link_libraries)
-+          list(REMOVE_ITEM _dnnl_link_libraries OpenMP::OpenMP_CXX)
++          list(REMOVE_ITEM _dnnl_link_libraries OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
 +          set_target_properties(dnnl PROPERTIES LINK_LIBRARIES "${_dnnl_link_libraries}")
 +        endif()
 +      endif()

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,14 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake | 32 ++++++++++++++++++++++++--------
- 1 file changed, 24 insertions(+), 8 deletions(-)
+ cmake/Dependencies.cmake | 38 ++++++++++++++++++++++++++++++--------
+ 1 file changed, 30 insertions(+), 8 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,30 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,36 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -27,6 +27,12 @@ index ef5c2fd4e97..4696cdd4505 100644
 +    set(MKLDNN_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 +    set(MKLDNN_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 +    set(DNNL_EXPERIMENTAL_UKERNEL ON CACHE BOOL "" FORCE)
++    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
++      # GCC's OpenMP runtime is libgomp. MKL builds use intel-openmp, so avoid
++      # introducing a second OpenMP runtime through bundled oneDNN.
++      set(DNNL_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
++      set(ONEDNN_CPU_RUNTIME SEQ CACHE STRING "" FORCE)
++    endif()
 +    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn)
 +
 +    if(MSVC AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,52 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake                         | 49 +++++++++++++++++++-----
+ cmake/Dependencies.cmake                         | 68 +++++++++++++++++++-----
  third_party/ideep/mkl-dnn/cmake/OpenMP.cmake     | 19 ++++++++--
- 2 files changed, 61 insertions(+), 15 deletions(-)
+ 2 files changed, 80 insertions(+), 15 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
+@@ -898,17 +898,36 @@ endif()
+ 
+ # ---[ OpenMP
+ if(USE_OPENMP AND NOT TARGET caffe2::openmp)
++  if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
++    find_library(ANACONDA_INTEL_OPENMP_LIBRARY NAMES iomp5 libiomp5 REQUIRED)
++    # GCC needs -fopenmp while compiling, but passing -fopenmp during the
++    # shared-library link makes it inject libgomp. Route the top-level PyTorch
++    # OpenMP target to Intel OpenMP for conda MKL builds instead.
++    set(OpenMP_C_FLAGS "-fopenmp" CACHE STRING "" FORCE)
++    set(OpenMP_CXX_FLAGS "-fopenmp" CACHE STRING "" FORCE)
++    set(OpenMP_C_LIB_NAMES iomp5 CACHE STRING "" FORCE)
++    set(OpenMP_CXX_LIB_NAMES iomp5 CACHE STRING "" FORCE)
++    set(OpenMP_iomp5_LIBRARY "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE FILEPATH "" FORCE)
++    set(OpenMP_C_LIBRARIES "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE STRING "" FORCE)
++    set(OpenMP_CXX_LIBRARIES "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE STRING "" FORCE)
++  endif()
+   include(${CMAKE_CURRENT_LIST_DIR}/Modules/FindOpenMP.cmake)
+   if(OPENMP_FOUND)
+     message(STATUS "Adding OpenMP CXX_FLAGS: " ${OpenMP_CXX_FLAGS})
+     if(APPLE AND USE_MPS)
+       string(APPEND CMAKE_OBJCXX_FLAGS " ${OpenMP_CXX_FLAGS}")
+     endif()
+     if(OpenMP_CXX_LIBRARIES)
+       message(STATUS "Will link against OpenMP libraries: ${OpenMP_CXX_LIBRARIES}")
+     endif()
+     add_library(caffe2::openmp INTERFACE IMPORTED)
+-    target_link_libraries(caffe2::openmp INTERFACE OpenMP::OpenMP_CXX)
++    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
++      target_compile_options(caffe2::openmp INTERFACE $<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>)
++      target_compile_options(caffe2::openmp INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
++      target_link_libraries(caffe2::openmp INTERFACE "${ANACONDA_INTEL_OPENMP_LIBRARY}")
++    else()
++      target_link_libraries(caffe2::openmp INTERFACE OpenMP::OpenMP_CXX)
++    endif()
+     list(APPEND Caffe2_DEPENDENCY_LIBS caffe2::openmp)
+     if(MSVC AND OpenMP_CXX_LIBRARIES MATCHES ".*libiomp5md\\.lib.*")
+       target_compile_definitions(caffe2::openmp INTERFACE _OPENMP_NOFORCE_MANIFEST)
 @@ -1479,14 +1479,49 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -4,14 +4,14 @@ Date: Fri, 6 Mar 2026 14:38:12 +0000
 Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  fix linking
 ---
- cmake/Dependencies.cmake | 24 ++++++++++++++++--------
- 1 file changed, 16 insertions(+), 8 deletions(-)
+ cmake/Dependencies.cmake | 32 ++++++++++++++++++++++++--------
+ 1 file changed, 24 insertions(+), 8 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
 index ef5c2fd4e97..4696cdd4505 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,22 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,30 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -28,6 +28,14 @@ index ef5c2fd4e97..4696cdd4505 100644
 +    set(MKLDNN_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 +    set(DNNL_EXPERIMENTAL_UKERNEL ON CACHE BOOL "" FORCE)
 +    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn)
++
++    if(MSVC AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)
++      find_library(ANACONDA_INTEL_OPENMP_LIBRARY NAMES libiomp5md REQUIRED)
++      # Match the rest of the MKL PyTorch stack on Windows: use Intel OpenMP,
++      # not the MSVC OpenMP runtime pulled in by /openmp defaults.
++      target_link_options(dnnl PRIVATE "/nodefaultlib:vcomp")
++      target_link_libraries(dnnl PRIVATE "${ANACONDA_INTEL_OPENMP_LIBRARY}")
++    endif()
 +
 +    # 1. OneDNN Source Headers (dnnl_graph.hpp)
 +    include_directories(AFTER SYSTEM ${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn/include)


### PR DESCRIPTION
pytorch openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14396](https://anaconda.atlassian.net/browse/PKG-14396) 

### Explanation of changes:

- Fix mkl builds linking with vcomp/libgomp AND intel-opemp
     - Add test to verify
- Fix CBC that was generating extra windows builds. 
- Explicitly pin openmp implementation being used. 

### Graphs
- [linux-aarch64](https://package-build.anaconda.com/v1/graph/9385b9a6-0c12-4e97-b9a7-676efef86df5)
- [linux-64](https://package-build.anaconda.com/v1/graph/c2a0157d-4d31-4bcb-95b1-15a57cef3109)
- [win-64](https://package-build.anaconda.com/v1/graph/499d1914-f244-432c-85a8-107ffae02ea0)
- [osx-arm64](https://package-build.anaconda.com/v1/graph/34e5e50b-6293-4aea-9858-8ad64cbd4a3c)

Needed to fix:
- https://github.com/AnacondaRecipes/bitsandbytes-feedstock/pull/4

[PKG-14396]: https://anaconda.atlassian.net/browse/PKG-14396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ