### PR TITLE
pytorch 2.12.0 — py3.10 + py3.11 sweep (2 of 3)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,14 +5,5 @@ extra_labels_for_os:
 
 task_timeout: 72000
 
-# Dev/staging channel — currently hosts:
-#   * pybind11 3.0.4 + pybind11-abi 11  (PKG-13552 pybind11-v3 migration)
-#   * optree 0.18.0 *_1 rebuilt against pybind11 3.0.4  (from optree-feedstock #6)
-# triton 3.7.0 is already on pkgs/main; no longer needs staging.
-# Remove this `channels:` block once pybind11 v3 lands on pkgs/main and the
-# 41-feedstock PKG-13552 rebuild completes.
-channels:
-  - xkong-staging
-
 # build_parameters:
 #  - "--no-test"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,9 +5,12 @@ extra_labels_for_os:
 
 task_timeout: 72000
 
-# Dev/staging channel for pre-release pybind11 3.0.4 + triton 3.7.0 builds while
-# PKG-13552 (pybind11-abi rebuild) and triton 3.7 PR #12 are still in scoping.
-# Remove before merging to master.
+# Dev/staging channel — currently hosts:
+#   * pybind11 3.0.4 + pybind11-abi 11  (PKG-13552 pybind11-v3 migration)
+#   * optree 0.18.0 *_1 rebuilt against pybind11 3.0.4  (from optree-feedstock #6)
+# triton 3.7.0 is already on pkgs/main; no longer needs staging.
+# Remove this `channels:` block once pybind11 v3 lands on pkgs/main and the
+# 41-feedstock PKG-13552 rebuild completes.
 channels:
   - xkong-staging
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,23 @@ export PACKAGE_TYPE=conda
 # remove pyproject.toml to avoid installing deps from pip
 rm -rf pyproject.toml
 
+# On linux+mkl, gate dnnl's OpenMP.cmake to use compile-only flags so gcc
+# doesn't auto-link libgomp into libdnnl.so. (Paired with patch 0022's
+# DNNL_CPU_RUNTIME=OMP + libiomp5 routing.)
+# Done via sed because the file lives inside the mkl-dnn submodule and a
+# patch-file approach fails on Windows worker — but Windows doesn't need
+# this fix anyway, MSVC iomp5 is routed via target properties in
+# Dependencies.cmake (patch 0022).
+if [[ "$target_platform" == linux-* && "$blas_impl" == "mkl" ]]; then
+    sed -i \
+        -e 's|append(CMAKE_C_FLAGS ${OpenMP_C_FLAGS})|add_compile_options($<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>)|' \
+        -e 's|append(CMAKE_CXX_FLAGS ${OpenMP_CXX_FLAGS})|add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)|' \
+        third_party/ideep/mkl-dnn/cmake/OpenMP.cmake
+    grep -q "add_compile_options.*COMPILE_LANGUAGE:C.*OpenMP_C_FLAGS" \
+        third_party/ideep/mkl-dnn/cmake/OpenMP.cmake \
+        || { echo "ERROR: dnnl OpenMP.cmake sed didn't apply"; exit 1; }
+fi
+
 # uncomment to debug cmake build
 # export CMAKE_VERBOSE_MAKEFILE=1
 
@@ -119,6 +136,19 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 else
     export CMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX${MACOSX_SDK_VERSION}.sdk"
     export CONDA_BUILD_SYSROOT="${CMAKE_OSX_SYSROOT}"
+    # SIR-3273 fix: the previous two exports were sufficient before the
+    # Taskcluster 95.x AMI rebuild because activation defaulted to the
+    # right SDK. After the rebuild, MacOSX.sdk symlink points at 12.1
+    # and activation pre-sets SDKROOT + CMAKE_ARGS to 12.1 too. clang
+    # honors SDKROOT and CMake honors -DCMAKE_OSX_SYSROOT= embedded in
+    # CMAKE_ARGS over our env overrides, so without these extra lines
+    # the compile still uses MacOSX12.1.sdk (which lacks Metal 3.0).
+    # Verified on PR #103 osx-arm64 metal debug build, graph
+    # 935c2593-eeac-41a8-8683-ec3e80f48478 — green with these 3 lines.
+    export SDKROOT="${CMAKE_OSX_SYSROOT}"
+    CMAKE_ARGS="${CMAKE_ARGS//MacOSX12.1.sdk/MacOSX${MACOSX_SDK_VERSION}.sdk}"
+    CMAKE_ARGS="${CMAKE_ARGS//-DCMAKE_OSX_DEPLOYMENT_TARGET=12.1/-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}}"
+    export CMAKE_ARGS
 fi
 #export TH_BINARY_BUILD=1
 # Use our build version and number for inserting into binaries
@@ -130,7 +160,28 @@ export PYTORCH_BUILD_NUMBER=0
 export INSTALL_TEST=0
 export BUILD_TEST=0
 
-export USE_SYSTEM_SLEEF=1
+# Use system sleef everywhere except linux+mkl. AR sleef hard-pins
+# `_openmp_mutex *_gnu` in its depends, which conflicts with intel-openmp's
+# `*_intel` in MKL builds. On linux+mkl, fall back to pytorch's bundled
+# sleef (third_party/sleef) which will link intel-openmp from the build
+# env — keeps MKL builds intel-only, matching AR's OpenMP policy
+# (perseverance-skills/sections/02_Package_building/02_Recipes/Pinnings.md).
+if [[ "$target_platform" == linux-* && "$blas_impl" == "mkl" ]]; then
+    export USE_SYSTEM_SLEEF=0
+    # AR OpenMP policy: linux+mkl must link intel-openmp only, not libgomp.
+    # gcc's default `-fopenmp` injects `-lgomp` at link → libtorch_cpu and
+    # other targets end up NEEDED libgomp.so.1. Override CMake's FindOpenMP
+    # to use libiomp5.so directly. (Patch 0022 covers the dnnl target via
+    # a more surgical target_link_libraries; this covers the rest.)
+    export CMAKE_ARGS="$CMAKE_ARGS \
+        -DOpenMP_C_FLAGS=-fopenmp \
+        -DOpenMP_CXX_FLAGS=-fopenmp \
+        -DOpenMP_C_LIB_NAMES=iomp5 \
+        -DOpenMP_CXX_LIB_NAMES=iomp5 \
+        -DOpenMP_iomp5_LIBRARY=$PREFIX/lib/libiomp5.so"
+else
+    export USE_SYSTEM_SLEEF=1
+fi
 # use our protobuf
 export BUILD_CUSTOM_PROTOBUF=OFF
 export USE_SYSTEM_PYBIND11=1
@@ -248,7 +299,11 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
         # aarch64 CUDA 13: upstream filters out <8.0, 7.5, 8.6 (x86_64-only SKUs)
         # and adds sm_11.0 (Jetson Thor) only on aarch64.
         # Keeps 8.0 (A100), 9.0 (Grace Hopper), 10.0+12.0 (Blackwell), 11.0 (Thor).
-        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0+PTX"
+        # sm_12.1+PTX is a deliberate divergence from upstream 2.12 for NVIDIA
+        # DGX Spark (GB10 Superchip, aarch64 Blackwell consumer/edge variant
+        # launched ~Apr 2026 after upstream 2.12's build_cuda.sh was written).
+        # Match what AR shipped in 2.11 (PR #95) for this customer.
+        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0;12.1+PTX"
     elif [[ ${cuda_compiler_version} == 12.* ]]; then
         # CUDA 12: sm_50-sm_61 deprecated in 12.8; sm_70 dropped upstream in 2.11.
         export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -136,15 +136,9 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 else
     export CMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX${MACOSX_SDK_VERSION}.sdk"
     export CONDA_BUILD_SYSROOT="${CMAKE_OSX_SYSROOT}"
-    # SIR-3273 fix: the previous two exports were sufficient before the
-    # Taskcluster 95.x AMI rebuild because activation defaulted to the
-    # right SDK. After the rebuild, MacOSX.sdk symlink points at 12.1
-    # and activation pre-sets SDKROOT + CMAKE_ARGS to 12.1 too. clang
-    # honors SDKROOT and CMake honors -DCMAKE_OSX_SYSROOT= embedded in
-    # CMAKE_ARGS over our env overrides, so without these extra lines
-    # the compile still uses MacOSX12.1.sdk (which lacks Metal 3.0).
-    # Verified on PR #103 osx-arm64 metal debug build, graph
-    # 935c2593-eeac-41a8-8683-ec3e80f48478 — green with these 3 lines.
+    # SIR-3273: post-AMI MacOSX.sdk symlinks to 12.1 and activation pre-sets
+    # SDKROOT + CMAKE_ARGS to match, overriding our env vars and pinning the
+    # compile to MacOSX12.1.sdk (no Metal 3.0). Override both explicitly.
     export SDKROOT="${CMAKE_OSX_SYSROOT}"
     CMAKE_ARGS="${CMAKE_ARGS//MacOSX12.1.sdk/MacOSX${MACOSX_SDK_VERSION}.sdk}"
     CMAKE_ARGS="${CMAKE_ARGS//-DCMAKE_OSX_DEPLOYMENT_TARGET=12.1/-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}}"
@@ -160,27 +154,26 @@ export PYTORCH_BUILD_NUMBER=0
 export INSTALL_TEST=0
 export BUILD_TEST=0
 
-# Use system sleef everywhere except linux+mkl. AR sleef hard-pins
-# `_openmp_mutex *_gnu` in its depends, which conflicts with intel-openmp's
-# `*_intel` in MKL builds. On linux+mkl, fall back to pytorch's bundled
-# sleef (third_party/sleef) which will link intel-openmp from the build
-# env — keeps MKL builds intel-only, matching AR's OpenMP policy
-# (perseverance-skills/sections/02_Package_building/02_Recipes/Pinnings.md).
+# Use the system sleef on all platforms — the OpenMP-flavor variant is pinned
+# per-platform in meta.yaml host (libgomp / llvm_openmp / no_openmp) to match
+# AR's OpenMP policy (perseverance-skills .../Pinnings.md).
+export USE_SYSTEM_SLEEF=1
+# linux+mkl: route the REST of pytorch's OpenMP (libtorch_cpu etc.) to
+# intel-openmp. gcc's default `-fopenmp` injects `-lgomp` at link, which would
+# make libtorch_cpu NEEDED libgomp.so.1 and violate AR's one-OpenMP-per-env
+# policy. Override CMake's FindOpenMP to use libiomp5.so directly. (Patch 0022
+# handles the dnnl target surgically; this covers everything else.)
+# Note: the old bundled-sleef fallback (USE_SYSTEM_SLEEF=0) is no longer needed
+# — sleef 3.9.0's no_openmp variant (sleef-feedstock #4) carries no
+# _openmp_mutex pin, so the system sleef no_openmp build pinned in meta.yaml
+# host has no mutex conflict with intel-openmp.
 if [[ "$target_platform" == linux-* && "$blas_impl" == "mkl" ]]; then
-    export USE_SYSTEM_SLEEF=0
-    # AR OpenMP policy: linux+mkl must link intel-openmp only, not libgomp.
-    # gcc's default `-fopenmp` injects `-lgomp` at link → libtorch_cpu and
-    # other targets end up NEEDED libgomp.so.1. Override CMake's FindOpenMP
-    # to use libiomp5.so directly. (Patch 0022 covers the dnnl target via
-    # a more surgical target_link_libraries; this covers the rest.)
     export CMAKE_ARGS="$CMAKE_ARGS \
         -DOpenMP_C_FLAGS=-fopenmp \
         -DOpenMP_CXX_FLAGS=-fopenmp \
         -DOpenMP_C_LIB_NAMES=iomp5 \
         -DOpenMP_CXX_LIB_NAMES=iomp5 \
         -DOpenMP_iomp5_LIBRARY=$PREFIX/lib/libiomp5.so"
-else
-    export USE_SYSTEM_SLEEF=1
 fi
 # use our protobuf
 export BUILD_CUSTOM_PROTOBUF=OFF
@@ -326,17 +319,10 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     # Cap glibc per-thread malloc arenas so long-running cicc/gcc processes
     # don't hold hundreds of MB of fragmented heap. No codegen impact.
     export MALLOC_ARENA_MAX=2
-    # Cap fbgemm_genai (CUTLASS) parallelism via a dedicated Ninja job pool
-    # (patch 0024). cutlass_heavy=4 lets 4 heavy CUTLASS TUs compile at once;
-    # observed RSS per cicc on g4dn.4xlarge T4 is ~4 GB, so 4× = ~16 GB peak,
-    # well under the 64 GB host budget. Was 1 originally (serialized) — that
-    # left 56 GB of RAM idle while MSLK FP4 GEMM kernels dominated wall time.
-    # Measured speedup on the MSLK FP4 tail (cutlass_heavy=1 → 4): ~3.4×.
-    # We tried =8 (PBP graph 2220751f): 13.0 dropped from 293→282 min (-3.8%),
-    # 12.9 went from 342→358 min (+4.7%) — net within noise floor. The MSLK
-    # tail saturates somewhere between 4 and 8 parallel TUs, so going higher
-    # adds memory pressure without real wall-time gains. Sticking with 4.
-    # Set as env vars so PyTorch setup.py auto-forwards them as -D
+    # Cap fbgemm_genai (CUTLASS) parallelism via Ninja job pool (patch 0024).
+    # cutlass_heavy=4 → ~16 GB peak (4 GB/cicc × 4), 3.4× speedup on MSLK FP4
+    # tail vs =1; =8 measured within noise. Env vars (not CMAKE_ARGS) because
+    # PyTorch setup.py auto-forwards them as -D.
     # (CMAKE_ARGS itself is not read by setup.py).
     export CMAKE_JOB_POOLS="cutlass_heavy=4;compile=${MAX_JOBS};link=2"
     export USE_FBGEMM_GENAI_JOB_POOL=cutlass_heavy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,8 +136,10 @@ requirements:
     {% endif %}
     # git is needed on ALL platforms because the source uses git_url +
     # git_rev (content-addressable; immune to GitHub asset regeneration).
-    - git              # [not win]
-    - msys2-git        # [win]
+    # Note on win: keep `- git` (not `msys2-git`) — msys2-git's POSIX-path
+    # git.exe fails conda-build's post-build `git status` step with
+    # "system cannot find the drive specified" (exit 128).
+    - git
     # libgomp's strong run_export pins _openmp_mutex *_gnu, which conflicts
     # with intel-openmp's *_intel on linux+mkl — scope to non-mkl linux only.
     - libgomp   # [linux and blas_impl != "mkl"]
@@ -359,9 +361,9 @@ outputs:
         - libcusolver-dev                        # [build_platform != target_platform]
         - libcusparse-dev                        # [build_platform != target_platform]
         {% endif %}
-        # git is needed on ALL platforms — see libtorch build section above.
-        - git              # [not win]
-        - msys2-git        # [win]
+        # git is needed on ALL platforms — see libtorch build section above
+        # (do NOT use msys2-git on win; conda-build invocation fails with it).
+        - git
         # See libtorch build section above for the openmp-mutex rationale —
         # libgomp's _openmp_mutex *_gnu run_export conflicts with intel-openmp's
         # _openmp_mutex *_intel on linux+mkl.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -523,7 +523,9 @@ outputs:
         # CUDA:
         #   test_ops.py::TestCommonCUDA::test_numpy_ref_nn_functional_
         #   pdist_cuda_float64 - Exception: name 'scipy' is not defined
-        - scipy
+        # scipy 1.17 dropped py3.10 (requires_python >=3.11), so we skip
+        # scipy on py3.10 — paired with `not test_numpy_ref` filter below.
+        - scipy           # [py != 310]
         - tabulate
         - pydot
         - mock  # [linux]
@@ -597,17 +599,24 @@ outputs:
         # ------------------------------------------------------------------------------------------------
         # Flaky complex linear-algebra cases (see run_test_core_k); https://github.com/pytorch/pytorch/issues/150918
         {% set run_test_core_k = "not (complex and (linalg_vecdot or dot or vdot))" %}
+        # py3.10: scipy 1.17 dropped py3.10 → scipy missing from test env → test_numpy_ref_*
+        # tests fail with `name 'scipy' is not defined`. Exclude them on py3.10 only.
+        {% set run_test_core_k_py310 = run_test_core_k ~ " and not test_numpy_ref" %}
         # linux-aarch64 CUDA packages are built with TORCH_CUDA_ARCH_LIST starting at sm_80 (see recipe/build.sh;
         # upstream aarch wheels omit <8.0 and 8.6). CI GPUs below sm_80 (e.g. some Jetson) hit
         # cudaErrorNoKernelImageForDevice loading kernels. TestBwdGradientsCUDA / test_inplace_gradgrad* fail from that
         # mismatch, not from functional PyTorch bugs on supported datacenter GPUs; exclude them only on this matrix.
         {% set run_test_core_k_aarch64_cuda = run_test_core_k ~ " and not inplace_gradgrad" %}
-        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k }}" || true # [not win and not (linux and aarch64 and (gpu_variant or "").startswith("cuda"))]
-        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k_aarch64_cuda }}" || true # [linux and aarch64 and (gpu_variant or "").startswith("cuda")]
+        {% set run_test_core_k_aarch64_cuda_py310 = run_test_core_k_aarch64_cuda ~ " and not test_numpy_ref" %}
+        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k }}" || true # [not win and not (linux and aarch64 and (gpu_variant or "").startswith("cuda")) and py != 310]
+        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k_py310 }}" || true # [not win and not (linux and aarch64 and (gpu_variant or "").startswith("cuda")) and py == 310]
+        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k_aarch64_cuda }}" || true # [linux and aarch64 and (gpu_variant or "").startswith("cuda") and py != 310]
+        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k_aarch64_cuda_py310 }}" || true # [linux and aarch64 and (gpu_variant or "").startswith("cuda") and py == 310]
         # lgamma or mvlgamma or multigammaln or gammaln all have these issues on a combination of Intel Xeon processors and Windows Server differences.
         # enabling these tests on windows will cause numerical differences in the test suite.
         # This is a non-deterministic issue where between 80-110 tests fail. This has been observed between Pytorch 2.5 and above.
-        - python ./test/run_test.py --core --continue-through-error -k "not ((complex and (linalg_vecdot or dot or vdot)) or lgamma or mvlgamma or multigammaln or gammaln)" || exit 0 # [win]
+        - python ./test/run_test.py --core --continue-through-error -k "not ((complex and (linalg_vecdot or dot or vdot)) or lgamma or mvlgamma or multigammaln or gammaln)" || exit 0 # [win and py != 310]
+        - python ./test/run_test.py --core --continue-through-error -k "not ((complex and (linalg_vecdot or dot or vdot)) or lgamma or mvlgamma or multigammaln or gammaln or test_numpy_ref)" || exit 0 # [win and py == 310]
         # The inductor tests test the torch.compile backend. Using the options below avoids running distributed tests,
         # which would be run if we used the --inductor option. (Distributed tests would only be correctly run on a multi-gpu test platform,
         # which we don't have.)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -116,11 +116,14 @@ build:
   # ("asm operand type size(4) does not match constraint 'l'"). Worked
   # around inline by bld.bat (sed-replace long2 → longlong2 in the affected
   # header); no skip needed.
-  # Per-Python skip: rotates each CI round. py3.13 was validated in graph
-  # 024f17c9 (round 1); this round runs py3.14 to catch deps that haven't
-  # been packaged for the new ABI. Flip back to a multi-py matrix (drop the
-  # skip entirely) before merging to master.
-  skip: true  # [py != 314]
+  # Python matrix split across 3 sibling PRs to stay under PBP graph-submitter
+  # Lambda /tmp capacity (SIR-2711 regression — 75-build full sweep errno 28).
+  # All three PRs share an identical recipe; only this skip line differs:
+  #   PR #97:  skip: true  # [py != 314]            (15 builds, validated)
+  #   THIS PR: skip: true  # [py != 310 and py != 311]   (30 builds)
+  #   PR #Y:   skip: true  # [py != 312 and py != 313]   (30 builds)
+  # Drop the skip entirely on the merge-to-master commit once all three green.
+  skip: true  # [py != 310 and py != 311]
   # osx-arm64 metal: AMI rebuild dropped MacOSX14.5.sdk (SIR-3273); skip
   # the metal variant until SIR-3273 lands so we don't burn the slot on
   # a known-broken build. CPU variant keeps building.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,9 +3,14 @@
 {% set rc = None %}
 {% set build = 0 %}
 
-
-# Keep this in sync with the release
-{% set smoke_test_commit = "4bd029011e0cef6881f439fb244d0369a8942e40" %}
+# Single source of truth: the commit SHA the v{{ version }} tag points at.
+# Drives BOTH the source git_rev AND the smoke_test fetches below — one SHA
+# to bump per release, nothing to "conjure" separately.
+# To resolve for a future release:
+#   gh api repos/pytorch/pytorch/git/refs/tags/v<version> --jq '.object.sha'
+# (de-reference annotated tags via .object.type == "tag" → /git/tags/<sha>.)
+{% set git_rev_sha = "0d62256a2b23365f8e1604297eb23a6545102aa8" %}
+{% set smoke_test_commit = git_rev_sha %}
 
 # see https://github.com/pytorch/pytorch/blame/v{{ version }}/.ci/docker/ci_commit_pins/triton.txt
 # 2.12 pins triton to release/3.7.x (commit b4e20bbe) — needs triton 3.7.0 in pkgs/main.
@@ -40,7 +45,7 @@ source:
   # times between 2026-05-13 and 2026-05-20). conda-build recursively fetches
   # submodules after clone, so third_party/* come from .gitmodules at this SHA.
   - git_url: https://github.com/pytorch/pytorch.git
-    git_rev: 0d62256a2b23365f8e1604297eb23a6545102aa8   # v2.12.0 GA
+    git_rev: {{ git_rev_sha }}   # v{{ version }} — see top-of-file derivation
     # NOTE: no git_depth pin. `git_depth: 1` makes conda-build do a shallow
     # `git clone --depth 1` (defaults to HEAD), then `git checkout v2.12.0`
     # fails because the tag isn't reachable in the shallow history. Full

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,5 @@
 {% set version = "2.12.0" %}
-# sha256 matches the GA release tarball content that was published 2026-05-13.
-# GitHub silently regenerated the release asset between 2026-05-13 and 2026-05-15:
-# a fresh download today returns 6a71b5f346cb08a6ae6fd63207c53a9bc7cae95dccfcd190bd9a43919f5f540a.
-# PBP workers cached the original tarball (sha 7cc1deb) when the GA flip landed,
-# so we keep this sha to match the cache. TODO: pin to git_url + commit for
-# bit-exact reproducibility, or invalidate PBP source cache and bump to 6a71b5f.
-{% set sha256 = "7cc1deb309f402ad67e9f45bbe311a40def4db19d66fddb9b01950f9bfc5ccb1" %}
 # Set the RC number to build release candidates. Set to None otherwise.
-# When rc != None, the GitHub auto-archive tarball is used (submodules included).
 {% set rc = None %}
 {% set build = 0 %}
 
@@ -41,11 +33,19 @@ package:
   version: {{ version }}
 
 source:
-{% if rc != None %}
-  # GitHub auto-archive tarball (includes vendored submodules — verified for v2.12.0-rc3).
-  # Patches apply against this tarball the same way as against the release tarball.
-  - url: https://github.com/pytorch/pytorch/archive/refs/tags/v{{ version }}-rc{{ rc }}.tar.gz
-    sha256: {{ sha256 }}
+  # Content-addressable source via git_url + git_rev: immune to GitHub asset
+  # regeneration. The v2.12.0 release tarball was silently re-generated
+  # between 2026-05-13 and 2026-05-15 (sha drift from 7cc1deb to 6a71b5f then
+  # back to 7cc1deb again by 2026-05-20), breaking fresh PBP worker fetches.
+  # conda-build recursively fetches submodules after clone, so pytorch's
+  # third_party/* are pinned via .gitmodules to the SHAs the v2.12.0 tag
+  # points at.
+  - git_url: https://github.com/pytorch/pytorch.git
+    git_rev: v{{ version }}{% if rc != None %}-rc{{ rc }}{% endif %}
+    # NOTE: no git_depth pin. `git_depth: 1` makes conda-build do a shallow
+    # `git clone --depth 1` (defaults to HEAD), then `git checkout v2.12.0`
+    # fails because the tag isn't reachable in the shallow history. Full
+    # clone (~430 MB) is fine — happens once per worker via src_cache.
     patches:
       - patches/0001-windows-FindMKL-add-library-suffix.patch                  # [win]
       - patches/0002-swap-openmp-search-precedence.patch                       # [blas_impl == "mkl"]
@@ -62,27 +62,6 @@ source:
       - patches/0022-force-bundled-mkldnn.patch
       - patches/0023-remove-conftest-extra-param.patch
       - patches/0024-Allow-fbgemm_genai-to-be-assigned-to-a-Ninja-job-pool.patch    # [linux and gpu_variant == "cuda"]
-{% else %}
-  # The "pytorch-v" release tarballs contain submodules; the "pytorch-" ones don't.
-  - url: https://github.com/pytorch/pytorch/releases/download/v{{ version }}/pytorch-v{{ version }}.tar.gz
-    sha256: {{ sha256 }}
-    patches:
-      - patches/0001-windows-FindMKL-add-library-suffix.patch                  # [win]
-      - patches/0002-swap-openmp-search-precedence.patch                       # [blas_impl == "mkl"]
-      - patches/0003-Force-usage-of-python-3-and-error-without-numpy.patch
-      # https://github.com/pytorch/pytorch/issues/150918 - continue tests on failure due to flaky tests
-      - patches/0007-continue-tests-on-failure.patch
-      - patches/0008-add-missing-includes.patch
-      - patches/0009-use-prefix-include-for-inductor.patch
-      - patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch             # [win]
-      - patches/0014-point-include-paths-to-PREFIX-include.patch
-      - patches/0015-point-lib-paths-to-PREFIX-lib.patch
-      - patches/0018-Add-USE_SYSTEM-options-for-KLEIDI-CUDNN_FRONTEND-CUT.patch
-      - patches/0021-fix-onednn-cuda-include.patch
-      - patches/0022-force-bundled-mkldnn.patch
-      - patches/0023-remove-conftest-extra-param.patch
-      - patches/0024-Allow-fbgemm_genai-to-be-assigned-to-a-Ninja-job-pool.patch    # [linux and gpu_variant == "cuda"]
-{% endif %}
   - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.ci/pytorch/smoke_test/smoke_test.py
     folder: smoke_test
   # check_wheel_tags.py is a sibling helper imported by smoke_test.py since the
@@ -93,10 +72,8 @@ source:
   # set, so it works fine on conda-installed packages.
   - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.ci/pytorch/smoke_test/check_wheel_tags.py
     folder: smoke_test
-  # The .gitignore is needed in order to run upstreams `setup.py clean`.
-  # Pin to smoke_test_commit so this works for both RC and GA; the v{{ version }}
-  # tag doesn't exist yet during pre-GA (rc != None).
-  - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.gitignore
+  # NOTE: .gitignore (required by upstream's `setup.py clean`) now comes
+  # from the git_url checkout above — no separate download needed.
 
 build:
   number: {{ build }}
@@ -121,14 +98,12 @@ build:
   # All three PRs share an identical recipe; only this skip line differs:
   #   PR #97:  skip: true  # [py != 314]            (15 builds, validated)
   #   THIS PR: skip: true  # [py != 310 and py != 311]   (30 builds)
-  #   PR #Y:   skip: true  # [py != 312 and py != 313]   (30 builds)
+  #   PR #102: skip: true  # [py != 312 and py != 313]   (30 builds)
   # Drop the skip entirely on the merge-to-master commit once all three green.
   skip: true  # [py != 310 and py != 311]
-  # osx-arm64 metal: AMI rebuild dropped MacOSX14.5.sdk (SIR-3273); skip
-  # the metal variant until SIR-3273 lands so we don't burn the slot on
-  # a known-broken build. CPU variant keeps building.
-  # TODO: re-enable when SIR-3273 closes.
-  skip: true  # [osx and arm64 and gpu_variant == "metal"]
+  # osx-arm64 metal: re-enabled after SIR-3273 root cause fix in build.sh
+  # (export SDKROOT + CMAKE_ARGS sed for 12.1 → MACOSX_SDK_VERSION).
+  # Verified on PR #103 debug graph 935c2593-eeac-41a8-8683-ec3e80f48478.
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                     # [gpu_variant == "cpu"]
@@ -177,11 +152,17 @@ requirements:
     - libcusolver-dev                        # [build_platform != target_platform]
     - libcusparse-dev                        # [build_platform != target_platform]
     {% endif %}
-    - git       # [not win]
-    - libgomp   # [linux]
+    # git is needed on ALL platforms because the source uses git_url +
+    # git_rev (content-addressable; immune to GitHub asset regeneration).
+    - git
+    # libgomp has a strong run_export of _openmp_mutex *_gnu; on linux+mkl
+    # that conflicts with intel-openmp's _openmp_mutex *_intel in host.
+    # Scope libgomp to non-mkl linux only — intel-openmp provides openmp
+    # runtime for the mkl variant.
+    - libgomp   # [linux and blas_impl != "mkl"]
     # This has a strong run_export so we don't need to put it in `host` or `run`
     # We use llvm-openmp for openblas variants on osx.
-    - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
+    - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
     - libuv     # [win]
     - cmake
     - ninja-base
@@ -234,14 +215,31 @@ requirements:
     - six
     - mkl-devel {{ mkl }}          # [blas_impl == "mkl"]
     - openblas-devel {{ openblas }}   # [blas_impl == "openblas"]
-    # We pull in the same versions of mkl and intel-openmp: intel aligns the versions
-    # We use intel-openmp for all mkl variants.
-    # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
+    # AR OpenMP policy (perseverance-skills/Pinnings.md):
+    #   - linux+mkl/win+mkl → intel-openmp (covered below)
+    #   - linux+openblas → libgomp (added here in host + run; matches
+    #     suitesparse-feedstock pattern)
+    #   - osx → llvm-openmp
+    # Strong run_exports from each pull the correct _openmp_mutex flavor.
     - intel-openmp {{ mkl }}         # [blas_impl == "mkl"]
-    - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
+    - libgomp                        # [linux and blas_impl == "openblas"]
+    - llvm-openmp                    # [osx and not (blas_impl == "mkl")]
     - libabseil {{ libabseil }}
     - libprotobuf {{ libprotobuf }}
-    - sleef 3.5.1
+    # sleef 3.9.0 with variant matching (per Eric Lundby's PR #100):
+    # the OpenMP-flavor variant must match the parent env's openmp runtime
+    # so torch_cpu.dll/.so doesn't get a mismatched DT_NEEDED.
+    #   - linux openblas → libgomp variant (matches AR libgcc *_gnu mutex)
+    #   - osx           → llvm_openmp variant (matches AR osx llvm-openmp)
+    #   - win or *+mkl  → no_openmp variant (sleef calls openmp internally
+    #                     via the parent process's runtime: intel-openmp
+    #                     on mkl, vcomp on win+openblas)
+    # On linux+mkl, pytorch falls back to bundled sleef via USE_SYSTEM_SLEEF=0
+    # because AR sleef 3.5.1 used to pin _openmp_mutex *_gnu hard; the
+    # 3.9.0 variant matrix avoids that, so we can re-include it everywhere.
+    - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
+    - sleef 3.9.0 *llvm_openmp*   # [osx]
+    - sleef 3.9.0 *no_openmp*     # [win or blas_impl == "mkl"]
     - libuv
     - pkg-config  # [unix]
     # upstream requirements-build.txt: typing-extensions>=4.15.0
@@ -258,10 +256,11 @@ requirements:
   # satisfy overlinking checks
   run:
     - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
+    - libgomp                                # [linux and blas_impl == "openblas"]
     - libuv                                  # [win]
     - {{ pin_compatible('magma') }}          # [(gpu_variant or "").startswith("cuda")]
     - {{ pin_compatible('libcudnn') }}          # [(gpu_variant or "").startswith("cuda")]
-    - __cuda                                    # [(gpu_variant or "").startswith("cuda")] 
+    - __cuda                                    # [(gpu_variant or "").startswith("cuda")]
 
 # these tests are for the libtorch output below, but due to
 # a particularity of conda-build, that output is defined in
@@ -271,6 +270,10 @@ test:
     # cmake needs a compiler to run package detection, see
     # https://discourse.cmake.org/t/questions-about-find-package-cli-msvc/6194
     - {{ compiler('cxx') }}
+    # PKG-14712: osx-arm64 ld64/cctools test-env clobber breaks C++ stdlib
+    # header lookup (cstdlib/iostream missing). Pin the c-stdlib provider
+    # explicitly so the test env always has a consistent toolchain.
+    - {{ stdlib('c') }}
     # for CMake config to find cuda & nvrtc
     - {{ compiler('cuda') }}    # [(gpu_variant or "").startswith("cuda")]
     - cuda-nvcc ={{ cuda_compiler_version }}     # [(gpu_variant or "").startswith("cuda")]
@@ -293,6 +296,11 @@ test:
     - cd cmake_test
     - cmake -GNinja -DCMAKE_CXX_STANDARD=17 $CMAKE_ARGS .   # [unix]
     - cmake -GNinja -DCMAKE_CXX_STANDARD=17 %CMAKE_ARGS% .  # [win]
+    # Verify dnnl.dll links Intel OpenMP (libiomp5md), not MSVC OpenMP
+    # (vcomp). Eric Lundby PR #100 patches cmake/Dependencies.cmake to
+    # force this; these asserts catch future regressions.
+    - dumpbin /dependents "%PREFIX%\Library\bin\dnnl.dll" | findstr /i libiomp5md            # [win and blas_impl == "mkl"]
+    - dumpbin /dependents "%PREFIX%\Library\bin\dnnl.dll" | findstr /i vcomp && exit /b 1 || exit /b 0  # [win and blas_impl == "mkl"]
 
 outputs:
   - name: libtorch
@@ -383,11 +391,15 @@ outputs:
         - libcusolver-dev                        # [build_platform != target_platform]
         - libcusparse-dev                        # [build_platform != target_platform]
         {% endif %}
-        - git       # [not win]
-        - libgomp   # [linux]
+        # git is needed on ALL platforms — see libtorch build section above.
+        - git
+        # See libtorch build section above for the openmp-mutex rationale —
+        # libgomp's _openmp_mutex *_gnu run_export conflicts with intel-openmp's
+        # _openmp_mutex *_intel on linux+mkl.
+        - libgomp   # [linux and blas_impl != "mkl"]
         # This has a strong run_export so we don't need to put it in `host` or `run`
         # We use llvm-openmp for openblas variants on osx.
-        - llvm-openmp 17             # [osx and not (blas_impl == "mkl")]
+        - llvm-openmp                # [osx and not (blas_impl == "mkl")]
         - cmake
         - ninja-base
         # Keep libprotobuf here so that a compatibile version
@@ -439,14 +451,19 @@ outputs:
         - six
         - mkl-devel {{ mkl }}             # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}   # [blas_impl == "openblas"]
-        # We pull in the same versions of mkl and intel-openmp: intel aligns the versions
-        # We use intel-openmp for all mkl variants.
-        # For openblas on win and linux, we don't specify any openmp implementation; it comes from the compiler.
+        # AR OpenMP policy — see libtorch host above for the full breakdown.
         - intel-openmp {{ mkl }}      # [blas_impl == "mkl"]
-        - llvm-openmp 17              # [osx and not (blas_impl == "mkl")]
+        - libgomp                     # [linux and blas_impl == "openblas"]
+        - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
         - libabseil
         - libprotobuf {{ libprotobuf }}
-        - sleef 3.5.1
+        # sleef: see libtorch host above for the 3.9.0 variant-matching
+        # rationale. On linux+mkl, pytorch still uses bundled sleef
+        # (USE_SYSTEM_SLEEF=0) so the host-side pin is for the resulting
+        # run dep ABI consistency.
+        - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
+        - sleef 3.9.0 *llvm_openmp*   # [osx]
+        - sleef 3.9.0 *no_openmp*     # [win or blas_impl == "mkl"]
         - libuv
         - pkg-config  # [unix]
         # upstream requirements-build.txt: typing-extensions>=4.15.0
@@ -462,6 +479,7 @@ outputs:
         - fmt {{ fmt }}
       run:
         - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
+        - libgomp                                # [linux and blas_impl == "openblas"]
         - llvm-openmp                            # [osx and not (blas_impl == "mkl")]
         # GPU requirements without run_exports
         - {{ pin_compatible('libcudnn') }}          # [(gpu_variant or "").startswith("cuda")]
@@ -494,10 +512,18 @@ outputs:
       requires:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        # PKG-14712: pin the c-stdlib provider so osx-arm64 test env has
+        # consistent C++ stdlib headers (cstdlib/iostream) — works around
+        # ld64/cctools clobber observed during pytorch QS env testing.
+        - {{ stdlib('c') }}
         - boto3
         - hypothesis
-        # SciPy optional upstream; nn.functional.pdist numpy-ref still calls scipy (seen on win+cuda).
-        - scipy  # [win]
+        # SciPy is needed by test_ops.py::test_numpy_ref_* on ALL platforms
+        # (not just win+cuda as previously assumed). Failure on linux-64 +
+        # CUDA:
+        #   test_ops.py::TestCommonCUDA::test_numpy_ref_nn_functional_
+        #   pdist_cuda_float64 - Exception: name 'scipy' is not defined
+        - scipy
         - tabulate
         - pydot
         - mock  # [linux]
@@ -509,6 +535,9 @@ outputs:
         - pytest-rerunfailures
         - pytest-flakefinder
         - pytest-xdist
+        # Needed for test_autograd.py::test_multi_grad_all_hooks
+        # (torch.utils.cpp_extension.load_inline requires ninja).
+        - ninja
         # Needed for test_autograd.py
         - pybind11 >=3.0.1,<4
         # the inductor "test_aoti_eager..." tests require objcopy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,15 +33,14 @@ package:
   version: {{ version }}
 
 source:
-  # Content-addressable source via git_url + git_rev: immune to GitHub asset
-  # regeneration. The v2.12.0 release tarball was silently re-generated
-  # between 2026-05-13 and 2026-05-15 (sha drift from 7cc1deb to 6a71b5f then
-  # back to 7cc1deb again by 2026-05-20), breaking fresh PBP worker fetches.
-  # conda-build recursively fetches submodules after clone, so pytorch's
-  # third_party/* are pinned via .gitmodules to the SHAs the v2.12.0 tag
-  # points at.
+  # Content-addressable source pinned to the exact commit v2.12.0 points at.
+  # Tags are mutable on GitHub — a retag would silently change our source —
+  # so we pin the SHA, not the tag. This also sidesteps the release-tarball
+  # regeneration that broke sha256-pinned fetches (asset re-generated several
+  # times between 2026-05-13 and 2026-05-20). conda-build recursively fetches
+  # submodules after clone, so third_party/* come from .gitmodules at this SHA.
   - git_url: https://github.com/pytorch/pytorch.git
-    git_rev: v{{ version }}{% if rc != None %}-rc{{ rc }}{% endif %}
+    git_rev: 0d62256a2b23365f8e1604297eb23a6545102aa8   # v2.12.0 GA
     # NOTE: no git_depth pin. `git_depth: 1` makes conda-build do a shallow
     # `git clone --depth 1` (defaults to HEAD), then `git checkout v2.12.0`
     # fails because the tag isn't reachable in the shallow history. Full
@@ -77,29 +76,12 @@ source:
 
 build:
   number: {{ build }}
-  # Platform coverage at py3.14: linux-64 (cpu/cuda12.9/cuda13.0 × openblas/mkl
-  # = 6), linux-aarch64 (cpu + cuda13.0 × openblas = 2), osx-arm64 (cpu only;
-  # metal blocked, see below), win-64 (same 6 as linux-64). Total 15 builds.
-  # mkl is x86_64-only (aggregate CBC gates it via `(x86 or x86_64) and not
-  # osx`), so aarch64/osx stay on openblas automatically.
-  #
-  # linux-aarch64 + CUDA: deliberately ships without triton per PKG-13219
-  # ("we will deliver without triton on linux-aarch64. We don't want this
-  # to be blocking."). triton is gated to `linux and x86_64` in the run-deps
-  # below (and so is the inductor test block). 2.11 shipped aarch64 CUDA the
-  # same way — torch.compile inductor backend is the only feature lost.
-  # win-64 + CUDA 12.9: cuda-cccl_win-64 12.9.27 ships a libcudacxx
-  # clusterlaunchcontrol.h header with an asm-constraint bug on MSVC
-  # ("asm operand type size(4) does not match constraint 'l'"). Worked
-  # around inline by bld.bat (sed-replace long2 → longlong2 in the affected
-  # header); no skip needed.
-  # Python matrix split across 3 sibling PRs to stay under PBP graph-submitter
-  # Lambda /tmp capacity (SIR-2711 regression — 75-build full sweep errno 28).
-  # All three PRs share an identical recipe; only this skip line differs:
-  #   PR #97:  skip: true  # [py != 314]            (15 builds, validated)
-  #   THIS PR: skip: true  # [py != 310 and py != 311]   (30 builds)
-  #   PR #102: skip: true  # [py != 312 and py != 313]   (30 builds)
-  # Drop the skip entirely on the merge-to-master commit once all three green.
+  # 30 builds at py3.10+3.11: linux-64 (cpu/cuda12.9/cuda13.0 × openblas/mkl),
+  # linux-aarch64 (cpu + cuda13.0, no triton per PKG-13219), osx-arm64 (cpu),
+  # win-64 (same 6 as linux-64). mkl is x86_64-only via aggregate CBC.
+  # Matrix split across 3 sibling PRs (SIR-2711 /tmp limit); recipe identical,
+  # only skip differs — #97 py3.14, #101 py3.10/3.11, #102 py3.12/3.13.
+  # Drop skip on merge-to-master once all three green.
   skip: true  # [py != 310 and py != 311]
   # osx-arm64 metal: re-enabled after SIR-3273 root cause fix in build.sh
   # (export SDKROOT + CMAKE_ARGS sed for 12.1 → MACOSX_SDK_VERSION).
@@ -154,11 +136,10 @@ requirements:
     {% endif %}
     # git is needed on ALL platforms because the source uses git_url +
     # git_rev (content-addressable; immune to GitHub asset regeneration).
-    - git
-    # libgomp has a strong run_export of _openmp_mutex *_gnu; on linux+mkl
-    # that conflicts with intel-openmp's _openmp_mutex *_intel in host.
-    # Scope libgomp to non-mkl linux only — intel-openmp provides openmp
-    # runtime for the mkl variant.
+    - git              # [not win]
+    - msys2-git        # [win]
+    # libgomp's strong run_export pins _openmp_mutex *_gnu, which conflicts
+    # with intel-openmp's *_intel on linux+mkl — scope to non-mkl linux only.
     - libgomp   # [linux and blas_impl != "mkl"]
     # This has a strong run_export so we don't need to put it in `host` or `run`
     # We use llvm-openmp for openblas variants on osx.
@@ -183,10 +164,9 @@ requirements:
     - nccl                   # [(gpu_variant or "").startswith("cuda") and linux]
     {% endif %}
     {% if cuda_major >= 12 %}
-    # cuda-driver-dev ships libcuda.so stub under targets/<arch>-linux/lib/stubs/;
-    # cmake's FindCUDAToolkit searches under the host prefix, so the driver
-    # stub must be in host (not just build) for pytorch 2.12 cuda.cmake to
-    # resolve CUDA::cuda_driver.
+    # cuda-driver-dev's libcuda.so stub must be in host (not just build):
+    # FindCUDAToolkit searches the host prefix, and pytorch 2.12's
+    # cuda.cmake link-resolves CUDA::cuda_driver at configure time.
     - cuda-driver-dev                        # [linux]
     - cuda-cudart-dev
     - cuda-cupti-dev
@@ -226,17 +206,12 @@ requirements:
     - llvm-openmp                    # [osx and not (blas_impl == "mkl")]
     - libabseil {{ libabseil }}
     - libprotobuf {{ libprotobuf }}
-    # sleef 3.9.0 with variant matching (per Eric Lundby's PR #100):
-    # the OpenMP-flavor variant must match the parent env's openmp runtime
-    # so torch_cpu.dll/.so doesn't get a mismatched DT_NEEDED.
-    #   - linux openblas → libgomp variant (matches AR libgcc *_gnu mutex)
-    #   - osx           → llvm_openmp variant (matches AR osx llvm-openmp)
-    #   - win or *+mkl  → no_openmp variant (sleef calls openmp internally
-    #                     via the parent process's runtime: intel-openmp
-    #                     on mkl, vcomp on win+openblas)
-    # On linux+mkl, pytorch falls back to bundled sleef via USE_SYSTEM_SLEEF=0
-    # because AR sleef 3.5.1 used to pin _openmp_mutex *_gnu hard; the
-    # 3.9.0 variant matrix avoids that, so we can re-include it everywhere.
+    # sleef 3.9.0 OpenMP-flavor variant must match parent env's runtime to
+    # avoid mismatched DT_NEEDED on torch_cpu:
+    #   linux+openblas → libgomp     (AR libgcc *_gnu mutex)
+    #   osx            → llvm_openmp (AR osx llvm-openmp)
+    #   win or *+mkl   → no_openmp   (sleef uses parent runtime: intel-openmp
+    #                                 on mkl, vcomp on win+openblas)
     - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
     - sleef 3.9.0 *llvm_openmp*   # [osx]
     - sleef 3.9.0 *no_openmp*     # [win or blas_impl == "mkl"]
@@ -249,7 +224,7 @@ requirements:
     # ABI-compatible up to 3.0.x; cap at 4.0 for future safety. pybind11-abi
     # explicitly included to pin the ABI version (PKG-13552; mamba-feedstock pattern).
     - pybind11 >=3.0.1,<4
-    - pybind11-abi
+    - pybind11-abi ==11     # strict — survives partial rebuilds
     - eigen {{ eigen }}
     - zlib {{ zlib }}
     - fmt {{ fmt }}
@@ -304,16 +279,9 @@ test:
 
 outputs:
   - name: libtorch
-    # Workaround for a win-64 conda-build wrapping change post-Taskcluster 95.x
-    # AMI rebuild (SIR-3210 / SIR-3264): when libtorch has no per-output script,
-    # conda-build inlines the top-level bld.bat into a generated IF-block
-    # wrapper instead of calling it as its own batch process. Inside that
-    # wrapper, CBC variant variables like %blas_impl% are empty, so bld.bat's
-    # BLAS check fails and the libtorch .conda artifact ships with 0 files.
-    # Giving libtorch its own per-output script (mirroring pytorch's
-    # build_pytorch.bat -> bld.bat pattern) forces a separate batch invocation
-    # where %blas_impl% is correctly populated. unix is unaffected; the
-    # top-level build.sh continues to run for the libtorch output there.
+    # SIR-3210/3264: post-AMI win-64, conda-build inlines bld.bat into an
+    # IF-wrapper where %blas_impl% is empty, producing a 0-file libtorch
+    # artifact. Per-output script forces a separate batch invocation. (unix unaffected.)
     script: build_libtorch.bat  # [win]
     build:
       missing_dso_whitelist:
@@ -392,7 +360,8 @@ outputs:
         - libcusparse-dev                        # [build_platform != target_platform]
         {% endif %}
         # git is needed on ALL platforms — see libtorch build section above.
-        - git
+        - git              # [not win]
+        - msys2-git        # [win]
         # See libtorch build section above for the openmp-mutex rationale —
         # libgomp's _openmp_mutex *_gnu run_export conflicts with intel-openmp's
         # _openmp_mutex *_intel on linux+mkl.
@@ -415,10 +384,7 @@ outputs:
         - cudnn                           # [(gpu_variant or "").startswith("cuda")]
         - nccl                            # [(gpu_variant or "").startswith("cuda") and linux]
         {% endif %}
-        # pytorch 2.12 BatchLinearAlgebra.cpp:55-57 #errors out when
         # MAGMA_VERSION_MINOR>=10 (deliberate guard — their AT_MAGMA_VERSION
-        # macro packs minor*10 and overflows). MAGMA 2.10.0 is on pkgs/main;
-        # cap to <2.10 until pytorch upstream rewrites the version macro.
         - magma <2.10                     # [(gpu_variant or "").startswith("cuda")]
         - nvtx-c                          # [(gpu_variant or "").startswith("cuda")]
         {% if cuda_major >= 12 %}
@@ -457,10 +423,7 @@ outputs:
         - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
         - libabseil
         - libprotobuf {{ libprotobuf }}
-        # sleef: see libtorch host above for the 3.9.0 variant-matching
-        # rationale. On linux+mkl, pytorch still uses bundled sleef
-        # (USE_SYSTEM_SLEEF=0) so the host-side pin is for the resulting
-        # run dep ABI consistency.
+        # sleef: see libtorch host above for the 3.9.0 variant-matching rationale.
         - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
         - sleef 3.9.0 *llvm_openmp*   # [osx]
         - sleef 3.9.0 *no_openmp*     # [win or blas_impl == "mkl"]
@@ -473,7 +436,7 @@ outputs:
         # upstream pytorch 2.12 vendors pybind11 3.0.1; ABI-compatible up to 3.0.x.
         # pybind11-abi explicit (PKG-13552, mamba pattern).
         - pybind11 >=3.0.1,<4
-        - pybind11-abi
+        - pybind11-abi ==11     # strict — survives partial rebuilds
         - eigen {{ eigen }}
         - zlib {{ zlib }}
         - fmt {{ fmt }}
@@ -518,13 +481,9 @@ outputs:
         - {{ stdlib('c') }}
         - boto3
         - hypothesis
-        # SciPy is needed by test_ops.py::test_numpy_ref_* on ALL platforms
-        # (not just win+cuda as previously assumed). Failure on linux-64 +
-        # CUDA:
-        #   test_ops.py::TestCommonCUDA::test_numpy_ref_nn_functional_
-        #   pdist_cuda_float64 - Exception: name 'scipy' is not defined
-        # scipy 1.17 dropped py3.10 (requires_python >=3.11), so we skip
-        # scipy on py3.10 — paired with `not test_numpy_ref` filter below.
+        # scipy needed by test_ops.py::test_numpy_ref_* on all platforms.
+        # scipy 1.17 dropped py3.10, so skip on py3.10 - paired with the
+        # `not test_numpy_ref` filter below.
         - scipy           # [py != 310]
         - tabulate
         - pydot

--- a/recipe/patches/0001-windows-FindMKL-add-library-suffix.patch
+++ b/recipe/patches/0001-windows-FindMKL-add-library-suffix.patch
@@ -9,10 +9,10 @@ This is required because our mdl-devel package contains libraries named like
  cmake/Modules/FindMKL.cmake | 15 +++++++++------
  1 file changed, 9 insertions(+), 6 deletions(-)
 
-Index: pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
+Index: pytorch-2.12.0/cmake/Modules/FindMKL.cmake
 ===================================================================
---- pytorch-2.12.0-rc3.orig/cmake/Modules/FindMKL.cmake
-+++ pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
+--- pytorch-2.12.0.orig/cmake/Modules/FindMKL.cmake
++++ pytorch-2.12.0/cmake/Modules/FindMKL.cmake
 @@ -124,6 +124,9 @@ ELSE(WIN32)
      ELSE()
        SET(mklthreads "mkl_intel_thread")

--- a/recipe/patches/0002-swap-openmp-search-precedence.patch
+++ b/recipe/patches/0002-swap-openmp-search-precedence.patch
@@ -6,10 +6,10 @@ Subject: [PATCH 02/13] Swap OpenMP search precedence to prefer Intel over GNU
  cmake/Modules/FindMKL.cmake | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-Index: pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
+Index: pytorch-2.12.0/cmake/Modules/FindMKL.cmake
 ===================================================================
---- pytorch-2.12.0-rc3.orig/cmake/Modules/FindMKL.cmake
-+++ pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
+--- pytorch-2.12.0.orig/cmake/Modules/FindMKL.cmake
++++ pytorch-2.12.0/cmake/Modules/FindMKL.cmake
 @@ -113,8 +113,8 @@ ELSE(WIN32)
        SET(mklthreads "mkl_tbb_thread")
        SET(mklrtls "tbb")

--- a/recipe/patches/0003-Force-usage-of-python-3-and-error-without-numpy.patch
+++ b/recipe/patches/0003-Force-usage-of-python-3-and-error-without-numpy.patch
@@ -7,10 +7,10 @@ Subject: [PATCH 01/16] Force usage of python 3 and error without numpy
  cmake/Dependencies.cmake | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+Index: pytorch-2.12.0/cmake/Dependencies.cmake
 ===================================================================
---- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
-+++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+--- pytorch-2.12.0.orig/cmake/Dependencies.cmake
++++ pytorch-2.12.0/cmake/Dependencies.cmake
 @@ -824,9 +824,9 @@ if(BUILD_PYTHON)
    if(USE_NUMPY)
      list(APPEND PYTHON_COMPONENTS NumPy)

--- a/recipe/patches/0007-continue-tests-on-failure.patch
+++ b/recipe/patches/0007-continue-tests-on-failure.patch
@@ -6,10 +6,10 @@ Subject: [PATCH 04/13] Continue tests on failure
  test/run_test.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-Index: pytorch-2.12.0-rc3/test/run_test.py
+Index: pytorch-2.12.0/test/run_test.py
 ===================================================================
---- pytorch-2.12.0-rc3.orig/test/run_test.py
-+++ pytorch-2.12.0-rc3/test/run_test.py
+--- pytorch-2.12.0.orig/test/run_test.py
++++ pytorch-2.12.0/test/run_test.py
 @@ -1271,7 +1271,7 @@ def get_pytest_args(options, is_cpp_test
      else:
          # When under the normal mode, retry a failed test NUM_PYTEST_RERUNS more times.

--- a/recipe/patches/0008-add-missing-includes.patch
+++ b/recipe/patches/0008-add-missing-includes.patch
@@ -11,10 +11,10 @@ case, they should be present.
  torch/csrc/distributed/c10d/control_plane/Handlers.hpp | 2 ++
  1 file changed, 2 insertions(+)
 
-Index: pytorch-2.12.0-rc3/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+Index: pytorch-2.12.0/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
 ===================================================================
---- pytorch-2.12.0-rc3.orig/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
-+++ pytorch-2.12.0-rc3/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+--- pytorch-2.12.0.orig/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
++++ pytorch-2.12.0/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
 @@ -4,6 +4,8 @@
  #include <map>
  #include <string>

--- a/recipe/patches/0009-use-prefix-include-for-inductor.patch
+++ b/recipe/patches/0009-use-prefix-include-for-inductor.patch
@@ -17,10 +17,10 @@ and https://github.com/conda-forge/pytorch-cpu-feedstock/issues/447.
  torch/_inductor/cpp_builder.py | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)
 
-Index: pytorch-2.12.0-rc3/torch/_inductor/cpp_builder.py
+Index: pytorch-2.12.0/torch/_inductor/cpp_builder.py
 ===================================================================
---- pytorch-2.12.0-rc3.orig/torch/_inductor/cpp_builder.py
-+++ pytorch-2.12.0-rc3/torch/_inductor/cpp_builder.py
+--- pytorch-2.12.0.orig/torch/_inductor/cpp_builder.py
++++ pytorch-2.12.0/torch/_inductor/cpp_builder.py
 @@ -1590,10 +1590,12 @@ def get_cpp_torch_options(
          + python_include_dirs
          + torch_include_dirs

--- a/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
+++ b/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
@@ -15,10 +15,10 @@ Suggested-By: Silvio Traversaro <silvio@traversaro.it>
  torch/lib/libshm_windows/CMakeLists.txt |  2 +-
  7 files changed, 16 insertions(+), 16 deletions(-)
 
-Index: pytorch-2.12.0-rc3/c10/CMakeLists.txt
+Index: pytorch-2.12.0/c10/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/c10/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/c10/CMakeLists.txt
+--- pytorch-2.12.0.orig/c10/CMakeLists.txt
++++ pytorch-2.12.0/c10/CMakeLists.txt
 @@ -162,7 +162,7 @@ if(NOT BUILD_LIBTORCHLESS)
    # Note: for now, we will put all export path into one single Caffe2Targets group
    # to deal with the cmake deployment need. Inside the Caffe2Targets set, the
@@ -28,10 +28,10 @@ Index: pytorch-2.12.0-rc3/c10/CMakeLists.txt
  endif()
  
  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-Index: pytorch-2.12.0-rc3/c10/cuda/CMakeLists.txt
+Index: pytorch-2.12.0/c10/cuda/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/c10/cuda/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/c10/cuda/CMakeLists.txt
+--- pytorch-2.12.0.orig/c10/cuda/CMakeLists.txt
++++ pytorch-2.12.0/c10/cuda/CMakeLists.txt
 @@ -86,7 +86,7 @@ if(NOT BUILD_LIBTORCHLESS)
  # Note: for now, we will put all export path into one single Caffe2Targets group
  # to deal with the cmake deployment need. Inside the Caffe2Targets set, the
@@ -41,10 +41,10 @@ Index: pytorch-2.12.0-rc3/c10/cuda/CMakeLists.txt
  
  endif()
  
-Index: pytorch-2.12.0-rc3/c10/hip/CMakeLists.txt
+Index: pytorch-2.12.0/c10/hip/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/c10/hip/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/c10/hip/CMakeLists.txt
+--- pytorch-2.12.0.orig/c10/hip/CMakeLists.txt
++++ pytorch-2.12.0/c10/hip/CMakeLists.txt
 @@ -56,7 +56,7 @@ if(NOT BUILD_LIBTORCHLESS)
        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
@@ -54,10 +54,10 @@ Index: pytorch-2.12.0-rc3/c10/hip/CMakeLists.txt
    set(C10_HIP_LIB c10_hip)
  endif()
  
-Index: pytorch-2.12.0-rc3/c10/xpu/CMakeLists.txt
+Index: pytorch-2.12.0/c10/xpu/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/c10/xpu/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/c10/xpu/CMakeLists.txt
+--- pytorch-2.12.0.orig/c10/xpu/CMakeLists.txt
++++ pytorch-2.12.0/c10/xpu/CMakeLists.txt
 @@ -49,7 +49,7 @@ if(NOT BUILD_LIBTORCHLESS)
        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
        $<INSTALL_INTERFACE:include>
@@ -67,10 +67,10 @@ Index: pytorch-2.12.0-rc3/c10/xpu/CMakeLists.txt
    set(C10_XPU_LIB c10_xpu)
    add_subdirectory(test)
  endif()
-Index: pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+Index: pytorch-2.12.0/caffe2/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/caffe2/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+--- pytorch-2.12.0.orig/caffe2/CMakeLists.txt
++++ pytorch-2.12.0/caffe2/CMakeLists.txt
 @@ -571,7 +571,7 @@ if(USE_CUDA)
    endif()
  
@@ -139,10 +139,10 @@ Index: pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
  endif()
  
  # ---[ Caffe2 HIP sources.
-Index: pytorch-2.12.0-rc3/torch/CMakeLists.txt
+Index: pytorch-2.12.0/torch/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/torch/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/torch/CMakeLists.txt
+--- pytorch-2.12.0.orig/torch/CMakeLists.txt
++++ pytorch-2.12.0/torch/CMakeLists.txt
 @@ -464,7 +464,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL
      set_target_properties(torch_python PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
  endif()
@@ -152,10 +152,10 @@ Index: pytorch-2.12.0-rc3/torch/CMakeLists.txt
  
  # Generate torch/version.py from the appropriate CMake cache variables.
  if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-Index: pytorch-2.12.0-rc3/torch/lib/libshm_windows/CMakeLists.txt
+Index: pytorch-2.12.0/torch/lib/libshm_windows/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/torch/lib/libshm_windows/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/torch/lib/libshm_windows/CMakeLists.txt
+--- pytorch-2.12.0.orig/torch/lib/libshm_windows/CMakeLists.txt
++++ pytorch-2.12.0/torch/lib/libshm_windows/CMakeLists.txt
 @@ -19,7 +19,7 @@ target_include_directories(shm PRIVATE
  target_link_libraries(shm torch c10)
  

--- a/recipe/patches/0014-point-include-paths-to-PREFIX-include.patch
+++ b/recipe/patches/0014-point-include-paths-to-PREFIX-include.patch
@@ -13,10 +13,10 @@ torch_include_dirs parameter.
  torch/utils/cpp_extension.py | 19 +++++--------------
  1 file changed, 5 insertions(+), 14 deletions(-)
 
-Index: pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+Index: pytorch-2.12.0/torch/utils/cpp_extension.py
 ===================================================================
---- pytorch-2.12.0-rc3.orig/torch/utils/cpp_extension.py
-+++ pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+--- pytorch-2.12.0.orig/torch/utils/cpp_extension.py
++++ pytorch-2.12.0/torch/utils/cpp_extension.py
 @@ -1620,29 +1620,20 @@ def include_paths(device_type: str = "cp
      """
      paths = []

--- a/recipe/patches/0015-point-lib-paths-to-PREFIX-lib.patch
+++ b/recipe/patches/0015-point-lib-paths-to-PREFIX-lib.patch
@@ -10,10 +10,10 @@ that's where are sos/dlls are.
  torch/utils/cpp_extension.py | 13 ++++++++++++-
  1 file changed, 12 insertions(+), 1 deletion(-)
 
-Index: pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+Index: pytorch-2.12.0/torch/utils/cpp_extension.py
 ===================================================================
---- pytorch-2.12.0-rc3.orig/torch/utils/cpp_extension.py
-+++ pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+--- pytorch-2.12.0.orig/torch/utils/cpp_extension.py
++++ pytorch-2.12.0/torch/utils/cpp_extension.py
 @@ -40,7 +40,18 @@ SHARED_FLAG = '/DLL' if IS_WINDOWS else
  
  _HERE = os.path.abspath(__file__)

--- a/recipe/patches/0018-Add-USE_SYSTEM-options-for-KLEIDI-CUDNN_FRONTEND-CUT.patch
+++ b/recipe/patches/0018-Add-USE_SYSTEM-options-for-KLEIDI-CUDNN_FRONTEND-CUT.patch
@@ -15,10 +15,10 @@ PR: https://github.com/pytorch/pytorch/pull/166824
  cmake/Summary.cmake          |  4 +++
  4 files changed, 74 insertions(+), 18 deletions(-)
 
-Index: pytorch-2.12.0-rc3/CMakeLists.txt
+Index: pytorch-2.12.0/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/CMakeLists.txt
+--- pytorch-2.12.0.orig/CMakeLists.txt
++++ pytorch-2.12.0/CMakeLists.txt
 @@ -507,6 +507,10 @@ option(USE_SYSTEM_BENCHMARK "Use system-
  option(USE_SYSTEM_ONNX "Use system-provided onnx." OFF)
  option(USE_SYSTEM_XNNPACK "Use system-provided xnnpack." OFF)
@@ -41,10 +41,10 @@ Index: pytorch-2.12.0-rc3/CMakeLists.txt
  endif()
  
  # /Z7 override option When generating debug symbols, CMake default to use the
-Index: pytorch-2.12.0-rc3/aten/src/ATen/CMakeLists.txt
+Index: pytorch-2.12.0/aten/src/ATen/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/aten/src/ATen/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/aten/src/ATen/CMakeLists.txt
+--- pytorch-2.12.0.orig/aten/src/ATen/CMakeLists.txt
++++ pytorch-2.12.0/aten/src/ATen/CMakeLists.txt
 @@ -797,8 +797,21 @@ if(USE_CUDA AND NOT USE_ROCM)
    add_definitions(-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1)
    add_definitions(-DCUTLASS_ENABLE_SM90_EXTENDED_MMA_SHAPES=1)
@@ -69,10 +69,10 @@ Index: pytorch-2.12.0-rc3/aten/src/ATen/CMakeLists.txt
  
    if($ENV{ATEN_STATIC_CUDA})
      if(CUDA_VERSION VERSION_LESS_EQUAL 12.9)
-Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+Index: pytorch-2.12.0/cmake/Dependencies.cmake
 ===================================================================
---- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
-+++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+--- pytorch-2.12.0.orig/cmake/Dependencies.cmake
++++ pytorch-2.12.0/cmake/Dependencies.cmake
 @@ -956,7 +956,14 @@ if(USE_CUDNN)
    if(CUDNN_VERSION VERSION_LESS 8.5)
      message(FATAL_ERROR "PyTorch needs CuDNN-8.5 or above, but found ${CUDNN_VERSION}. Builds are still possible with `USE_CUDNN=0`")
@@ -166,10 +166,10 @@ Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
  
  # ---[ Kineto
  # edge profiler depends on KinetoProfiler but it only does cpu
-Index: pytorch-2.12.0-rc3/cmake/Summary.cmake
+Index: pytorch-2.12.0/cmake/Summary.cmake
 ===================================================================
---- pytorch-2.12.0-rc3.orig/cmake/Summary.cmake
-+++ pytorch-2.12.0-rc3/cmake/Summary.cmake
+--- pytorch-2.12.0.orig/cmake/Summary.cmake
++++ pytorch-2.12.0/cmake/Summary.cmake
 @@ -82,7 +82,9 @@ function(caffe2_print_configuration_summ
      message(STATUS "    USE_MEM_EFF_ATTENTION : ${USE_MEM_EFF_ATTENTION}")
      if(${USE_CUDNN})

--- a/recipe/patches/0021-fix-onednn-cuda-include.patch
+++ b/recipe/patches/0021-fix-onednn-cuda-include.patch
@@ -6,10 +6,10 @@ Subject: [PATCH 12/13] Force OneDNN headers for BOTH CPU and CUDA targets
  caffe2/CMakeLists.txt | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
-Index: pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+Index: pytorch-2.12.0/caffe2/CMakeLists.txt
 ===================================================================
---- pytorch-2.12.0-rc3.orig/caffe2/CMakeLists.txt
-+++ pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+--- pytorch-2.12.0.orig/caffe2/CMakeLists.txt
++++ pytorch-2.12.0/caffe2/CMakeLists.txt
 @@ -2104,3 +2104,16 @@ if(MSVC)
    endforeach()
  endif()

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -3,10 +3,10 @@
 # Date: Fri, 6 Mar 2026 14:38:12 +0000
 # Imported from AnacondaRecipes/pytorch-feedstock PR #100 (Eric Lundby).
 
-Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+Index: pytorch-2.12.0/cmake/Dependencies.cmake
 ===================================================================
---- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
-+++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+--- pytorch-2.12.0.orig/cmake/Dependencies.cmake
++++ pytorch-2.12.0/cmake/Dependencies.cmake
 @@ -1479,14 +1479,49 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -1,17 +1,13 @@
-From c271d3edd2e8790ab16864360346345890efc4c4 Mon Sep 17 00:00:00 2001
-From: James Robertson <jrobertson@anaconda.com>
-Date: Fri, 6 Mar 2026 14:38:12 +0000
-Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
- fix linking
----
- cmake/Dependencies.cmake | 24 ++++++++++++++++--------
- 1 file changed, 16 insertions(+), 8 deletions(-)
+# [PATCH] Force bundled OneDNN build, enable experimental kernels, and fix linking
+# From: James Robertson <jrobertson@anaconda.com>
+# Date: Fri, 6 Mar 2026 14:38:12 +0000
+# Imported from AnacondaRecipes/pytorch-feedstock PR #100 (Eric Lundby).
 
 Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
 ===================================================================
 --- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
 +++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
-@@ -1522,14 +1522,22 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1479,14 +1479,49 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -27,7 +23,34 @@ Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
 +    set(MKLDNN_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 +    set(MKLDNN_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 +    set(DNNL_EXPERIMENTAL_UKERNEL ON CACHE BOOL "" FORCE)
++    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl")
++      find_library(ANACONDA_INTEL_OPENMP_LIBRARY NAMES iomp5 libiomp5 REQUIRED)
++      # Keep oneDNN fully OpenMP-enabled for MKL builds, but route GCC builds
++      # to Intel OpenMP. oneDNN's OpenMP.cmake is patched below so -fopenmp is
++      # compile-only; otherwise GCC injects -lgomp during libdnnl.so linking.
++      set(DNNL_CPU_RUNTIME OMP CACHE STRING "" FORCE)
++      set(ONEDNN_CPU_RUNTIME OMP CACHE STRING "" FORCE)
++      set(OpenMP_C_FLAGS "-fopenmp" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_FLAGS "-fopenmp" CACHE STRING "" FORCE)
++      set(OpenMP_C_LIB_NAMES iomp5 CACHE STRING "" FORCE)
++      set(OpenMP_CXX_LIB_NAMES iomp5 CACHE STRING "" FORCE)
++      set(OpenMP_iomp5_LIBRARY "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE FILEPATH "" FORCE)
++      set(OpenMP_C_LIBRARIES "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE STRING "" FORCE)
++      set(OpenMP_CXX_LIBRARIES "${ANACONDA_INTEL_OPENMP_LIBRARY}" CACHE STRING "" FORCE)
++    endif()
 +    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn)
++
++    if(UNIX AND NOT APPLE AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)
++      target_link_libraries(dnnl PRIVATE "${ANACONDA_INTEL_OPENMP_LIBRARY}")
++    endif()
++
++    if(MSVC AND "$ENV{blas_impl}" STREQUAL "mkl" AND TARGET dnnl)
++      find_library(ANACONDA_INTEL_OPENMP_LIBRARY NAMES libiomp5md REQUIRED)
++      # Match the rest of the MKL PyTorch stack on Windows: use Intel OpenMP,
++      # not the MSVC OpenMP runtime pulled in by /openmp defaults.
++      target_link_options(dnnl PRIVATE "/nodefaultlib:vcomp")
++      target_link_libraries(dnnl PRIVATE "${ANACONDA_INTEL_OPENMP_LIBRARY}")
++    endif()
 +
 +    # 1. OneDNN Source Headers (dnnl_graph.hpp)
 +    include_directories(AFTER SYSTEM ${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn/include)

--- a/recipe/patches/0023-remove-conftest-extra-param.patch
+++ b/recipe/patches/0023-remove-conftest-extra-param.patch
@@ -11,10 +11,10 @@ This fixes compatibility with pytest 9+.
  test/conftest.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-Index: pytorch-2.12.0-rc3/test/conftest.py
+Index: pytorch-2.12.0/test/conftest.py
 ===================================================================
---- pytorch-2.12.0-rc3.orig/test/conftest.py
-+++ pytorch-2.12.0-rc3/test/conftest.py
+--- pytorch-2.12.0.orig/test/conftest.py
++++ pytorch-2.12.0/test/conftest.py
 @@ -233,7 +233,7 @@ def pytest_terminal_summary(terminalrepo
  
  


### PR DESCRIPTION
pytorch 2.12.0 — py3.10 + py3.11 sweep (2 of 3)

**Destination channel:** defaults

### Links

- [PKG-12876](https://anaconda.atlassian.net/browse/PKG-12876) — Pytorch 2.12 (parent epic)
- [Upstream repository](https://github.com/pytorch/pytorch)
- [Upstream changelog/diff](https://github.com/pytorch/pytorch/compare/v2.11.0...v2.12.0)
- Sibling PRs (3-PR matrix split, identical recipe except for `build.skip`):
  - [#97](https://github.com/AnacondaRecipes/pytorch-feedstock/pull/97) — py3.14 (1 of 3)
  - [#102](https://github.com/AnacondaRecipes/pytorch-feedstock/pull/102) — py3.12 + py3.13 (3 of 3)

### Explanation of changes:

- **Matrix split context.** 3-PR split forced by PBP graph-submitter Lambda exhausting `/tmp` (errno 28, [SIR-2711](https://anaconda.atlassian.net/browse/SIR-2711) regression). The recipe is byte-identical to PR #97 except for the `build.skip` per-Python selector line
- Reviewing PR #97 validates the recipe for this PR.


[PKG-12876]: https://anaconda.atlassian.net/browse/PKG-12876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIR-2711]: https://anaconda.atlassian.net/browse/SIR-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ