### PR TITLE
pytorch 2.12.0 — SIR-3273 osx-arm64 metal SDK diagnostic (DO NOT MERGE)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,5 +5,11 @@ extra_labels_for_os:
 
 task_timeout: 72000
 
+# Dev/staging channel for pre-release pybind11 3.0.4 + triton 3.7.0 builds while
+# PKG-13552 (pybind11-abi rebuild) and triton 3.7 PR #12 are still in scoping.
+# Remove before merging to master.
+channels:
+  - xkong-staging
+
 # build_parameters:
 #  - "--no-test"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -153,9 +153,8 @@ if "%PKG_NAME%" == "pytorch" (
 @REM Use pip instead of raw setup.py for a cleaner build flow.
 @REM --no-clean preserves build dir so CMake can do incremental work.
 @REM --no-build-isolation uses our conda environment packages.
-@REM TEMP DEBUG: dropped --config-settings=--global-option=-q so setup.py output
-@REM is visible (need to diagnose 2.12-rc3 wheel build failure). Restore once green.
-%PYTHON% -m pip %PIP_ACTION% . --no-build-isolation --no-deps %PIP_VERBOSITY% --no-clean
+@REM --config-settings=--global-option=-q reduces setup.py noise.
+%PYTHON% -m pip %PIP_ACTION% . --no-build-isolation --no-deps %PIP_VERBOSITY% --no-clean --config-settings=--global-option=-q
 if %ERRORLEVEL% neq 0 exit 1
 
 @REM ========================= PACKAGE SPLIT ====================================

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -153,8 +153,9 @@ if "%PKG_NAME%" == "pytorch" (
 @REM Use pip instead of raw setup.py for a cleaner build flow.
 @REM --no-clean preserves build dir so CMake can do incremental work.
 @REM --no-build-isolation uses our conda environment packages.
-@REM --config-settings=--global-option=-q reduces setup.py noise.
-%PYTHON% -m pip %PIP_ACTION% . --no-build-isolation --no-deps %PIP_VERBOSITY% --no-clean --config-settings=--global-option=-q
+@REM TEMP DEBUG: dropped --config-settings=--global-option=-q so setup.py output
+@REM is visible (need to diagnose 2.12-rc3 wheel build failure). Restore once green.
+%PYTHON% -m pip %PIP_ACTION% . --no-build-isolation --no-deps %PIP_VERBOSITY% --no-clean
 if %ERRORLEVEL% neq 0 exit 1
 
 @REM ========================= PACKAGE SPLIT ====================================

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -59,26 +59,33 @@ if "%gpu_variant:~0,4%" == "cuda" (
     set USE_NCCL=0
     set USE_STATIC_NCCL=0
 
-    @REM CUDA Architecture List (aligned with upstream PyTorch CI)
+    @REM CUDA Architecture List (aligned with upstream PyTorch v2.12.0 .ci/manywheel/build_cuda.sh)
     @REM  7.5 = Turing     (RTX 20xx, T4)
     @REM  8.0 = Ampere HPC (A100)
     @REM  8.6 = Ampere     (RTX 30xx)
     @REM  9.0 = Hopper     (H100, H200)
     @REM 10.0 = Blackwell  (GB200, B200)
     @REM 12.0 = Blackwell  (RTX 50xx, RTX PRO)
-    @REM +PTX = forward compat via JIT for future archs
     @REM sm_70 (Volta/V100) dropped upstream in 2.11 for CUDA 12 and CUDA 13.
+    @REM Upstream 2.12 dropped trailing +PTX from both lists.
     set "cuda_major=%cuda_compiler_version:~0,2%"
     if "!cuda_major!" == "12" (
-        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0"
     ) else if "!cuda_major!" == "13" (
-        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0"
     ) else (
         echo [ERROR] No CUDA architecture list exists for CUDA v%cuda_compiler_version%
         echo Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one.
         exit /b 1
     )
-    set "TORCH_NVCC_FLAGS=-Xfatbin -compress-all"
+    @REM TORCH_NVCC_FLAGS: --threads 2 parallelizes nvcc within each translation unit.
+    @REM CUDA 13 also adds -compress-mode=size and BUILD_BUNDLE_PTXAS=1 (matches upstream
+    @REM 2.12 .ci/manywheel/build_cuda.sh).
+    set "TORCH_NVCC_FLAGS=-Xfatbin -compress-all --threads 2"
+    if "!cuda_major!" == "13" (
+        set "TORCH_NVCC_FLAGS=!TORCH_NVCC_FLAGS! -compress-mode=size"
+        set BUILD_BUNDLE_PTXAS=1
+    )
 
     @REM Suppress extremely noisy ptxas advisories that bloat logs
     set "CMAKE_CUDA_FLAGS=-w -Xptxas -w"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -81,13 +81,12 @@ if "%gpu_variant:~0,4%" == "cuda" (
         exit /b 1
     )
     @REM TORCH_NVCC_FLAGS: --threads 2 parallelizes nvcc within each translation unit.
-    @REM CUDA 13 also adds -compress-mode=size and BUILD_BUNDLE_PTXAS=1 (matches upstream
-    @REM 2.12 .ci/manywheel/build_cuda.sh).
+    @REM Do NOT set BUILD_BUNDLE_PTXAS on Windows: pytorch's CMakeLists.txt:1467
+    @REM does `file(COPY "${CUDAToolkit_BIN_DIR}/ptxas" ...)` with the literal
+    @REM Linux name `ptxas` — on Windows the binary is `ptxas.exe`, so the
+    @REM copy fails with "cannot find ... ptxas: File exists". Master (2.11)
+    @REM never set it on win; we don't need PTXAS bundled on win either.
     set "TORCH_NVCC_FLAGS=-Xfatbin -compress-all --threads 2"
-    if "!cuda_major!" == "13" (
-        set "TORCH_NVCC_FLAGS=!TORCH_NVCC_FLAGS! -compress-mode=size"
-        set BUILD_BUNDLE_PTXAS=1
-    )
 
     @REM Suppress extremely noisy ptxas advisories that bloat logs
     set "CMAKE_CUDA_FLAGS=-w -Xptxas -w"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -67,12 +67,14 @@ if "%gpu_variant:~0,4%" == "cuda" (
     @REM 10.0 = Blackwell  (GB200, B200)
     @REM 12.0 = Blackwell  (RTX 50xx, RTX PRO)
     @REM sm_70 (Volta/V100) dropped upstream in 2.11 for CUDA 12 and CUDA 13.
-    @REM Upstream 2.12 dropped trailing +PTX from both lists.
+    @REM We deliberately keep trailing +PTX for forward-compat with future archs
+    @REM (sm_13+). Upstream 2.11 shipped +PTX; upstream 2.12 dropped it. We preserve
+    @REM it so users on hardware newer than sm_12 still get JIT-runnable kernels.
     set "cuda_major=%cuda_compiler_version:~0,2%"
     if "!cuda_major!" == "12" (
-        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0"
+        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
     ) else if "!cuda_major!" == "13" (
-        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0"
+        set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
     ) else (
         echo [ERROR] No CUDA architecture list exists for CUDA v%cuda_compiler_version%
         echo Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -101,6 +101,20 @@ if "%gpu_variant:~0,4%" == "cuda" (
     set "PATH=%CUDA_BIN_PATH%;%PATH%"
     set CUDNN_INCLUDE_DIR=%LIBRARY_PREFIX%\include
     set "CUDA_VERSION=%cuda_compiler_version%"
+
+    @REM ==================== libcudacxx clusterlaunchcontrol patch ===============
+    @REM cuda-cccl_win-64 12.9.27 ships a libcudacxx header with an asm-constraint
+    @REM bug that fails to compile on Windows MSVC:
+    @REM   clusterlaunchcontrol.h(78): error: asm operand type size(4) does not
+    @REM   match type/size implied by constraint 'l'
+    @REM Root cause: the header casts to `long2*` and feeds .x/.y into asm with
+    @REM constraint 'l' (64-bit). On Linux x86_64 LP64 `long` is 64-bit (works);
+    @REM on Windows MSVC LLP64 `long` is 32-bit (size mismatch). Fixed upstream
+    @REM in CUDA 13.0+. For 12.9 we sed-replace long2 with longlong2 (64-bit on
+    @REM both platforms) in the host- and build-env copies of the header.
+    if "%cuda_compiler_version%"=="12.9" (
+        powershell -NoProfile -Command "@('%BUILD_PREFIX%','%PREFIX%') | ForEach-Object { $p = Join-Path $_ 'Library\include\targets\x64\cuda\__ptx\instructions\generated\clusterlaunchcontrol.h'; if (Test-Path $p) { $orig = Get-Content $p -Raw; $patched = $orig -replace 'reinterpret_cast<long2\*>', 'reinterpret_cast<longlong2*>'; if ($patched -ne $orig) { Set-Content -Path $p -Value $patched -NoNewline; Write-Host \"libcudacxx patch applied: $p\" } } }"
+    )
 ) else (
     set USE_CUDA=0
     set "USE_MKLDNN=1"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -163,11 +163,13 @@ elif [[ "$target_platform" == "linux-aarch64" && ${gpu_variant} == "cuda"* ]]; t
     # CUDA template instantiation (flash attention / cutlass) is extremely
     # memory-hungry. Cap parallelism to avoid OOM.
     export MAX_JOBS=4
-elif [[ "$target_platform" == "linux-x86_64" && ${gpu_variant} == "cuda"* ]]; then
+elif [[ "$target_platform" == "linux-64" && ${gpu_variant} == "cuda"* ]]; then
     # CUDA template instantiation (flash attention / cutlass) is extremely
     # memory-hungry. Cap parallelism to avoid OOM.
-    # 6 seems to be the sweet spot for the CI runners (April 2026)
-    export MAX_JOBS=6
+    # MAX_JOBS=15 (CPU_COUNT-1) verified safe on g4dn.4xlarge (16 vCPU / 64GB) in 2.10.0.
+    # NOTE: target_platform is "linux-64" on conda; the previous "linux-x86_64"
+    # literal never matched and silently fell through to the else branch.
+    export MAX_JOBS=$((CPU_COUNT > 1 ? CPU_COUNT - 1 : 1))
 else
     # Leave a spare core for other tasks. This may need to be reduced further
     # if we get out of memory errors. (Each job uses a certain amount of memory.)
@@ -236,19 +238,20 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     if [[ "${target_platform}" != "${build_platform}" ]]; then
         export CUDA_TOOLKIT_ROOT=${CUDA_HOME}
     fi
+    # CUDA arch lists aligned with upstream PyTorch v2.12.0 .ci/manywheel/build_cuda.sh.
+    # 2.12 supports CUDA 12.6/12.8/12.9/13.0/13.2; we ship 12.9 and 13.0
+    # (pkgs/main has cuda-nvcc 13.0 but not 13.2 yet — see CBC).
     if [[ "$target_platform" == "linux-aarch64" && ${cuda_compiler_version} == 13.* ]]; then
-        # aarch64: upstream filters out <8.0 and 8.6 (x86_64-only SKUs).
-        # Keeps 8.0 (A100), 9.0 (Grace Hopper), 10.0+12.0 (Blackwell).
-        # aarch64 CUDA 13: same filter plus sm_11.0 added upstream specifically for aarch64.
-        # https://github.com/pytorch/pytorch/blob/v2.10.0/.ci/manywheel/build_cuda.sh
-        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0;12.1+PTX"
+        # aarch64 CUDA 13: upstream filters out <8.0, 7.5, 8.6 (x86_64-only SKUs)
+        # and adds sm_11.0 (Jetson Thor) only on aarch64.
+        # Keeps 8.0 (A100), 9.0 (Grace Hopper), 10.0+12.0 (Blackwell), 11.0 (Thor).
+        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0"
     elif [[ ${cuda_compiler_version} == 12.* ]]; then
-        # Arch list aligned with upstream PyTorch CI.
-        # sm_50-sm_61 deprecated in CUDA 12.8; sm_70 dropped upstream in 2.11.
-        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+        # CUDA 12: sm_50-sm_61 deprecated in 12.8; sm_70 dropped upstream in 2.11.
+        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0"
     elif [[ ${cuda_compiler_version} == 13.* ]]; then
-        # sm_70 dropped in CUDA 13; list matches upstream PyTorch CI for CUDA 13.
-        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+        # CUDA 13: sm_70 dropped; same arch list as 12.x for x86_64.
+        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0"
     else
         echo "No CUDA architecture list exists for CUDA v${cuda_compiler_version}"
         echo "in build.sh. Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one."
@@ -258,7 +261,14 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     if [[ "${target_platform}" != "${build_platform}" ]]; then
         export CUDA_TOOLKIT_ROOT=${PREFIX}
     fi
-    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+    # TORCH_NVCC_FLAGS: --threads 2 parallelizes nvcc within each translation unit.
+    # CUDA 13 also gets -compress-mode=size and BUILD_BUNDLE_PTXAS=1 (matches upstream
+    # 2.12 .ci/manywheel/build_cuda.sh).
+    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all --threads 2"
+    if [[ ${cuda_compiler_version} == 13.* ]]; then
+        export TORCH_NVCC_FLAGS="${TORCH_NVCC_FLAGS} -compress-mode=size"
+        export BUILD_BUNDLE_PTXAS=1
+    fi
     export NCCL_ROOT_DIR=$PREFIX
     export NCCL_INCLUDE_DIR=$PREFIX/include
     export USE_SYSTEM_NCCL=1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -291,6 +291,13 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     export USE_SYSTEM_NVTX=1
     export MAGMA_HOME="${PREFIX}"
     export CUDA_INC_PATH="${PREFIX}/targets/$(uname -m)-linux/include/"
+    # pytorch 2.12 + CMake 4.x: cmake/public/cuda.cmake creates an INTERFACE
+    # target caffe2::cuda → CUDA::cuda_driver, validated eagerly at generate.
+    # The driver stub from cuda-driver-dev lives under targets/<arch>-linux/lib/stubs/
+    # which FindCUDAToolkit doesn't search by default. Point cmake at it.
+    _arch="$(uname -m)"
+    export CMAKE_LIBRARY_PATH="${BUILD_PREFIX}/targets/${_arch}-linux/lib/stubs:${PREFIX}/targets/${_arch}-linux/lib/stubs:${CMAKE_LIBRARY_PATH}"
+    export CUDA_cuda_driver_LIBRARY="${BUILD_PREFIX}/targets/${_arch}-linux/lib/stubs/libcuda.so"
 else
     # MKLDNN is an Apache-2.0 licensed library for DNNs and is used
     # for CPU builds. Not to be confused with MKL.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -299,14 +299,19 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     export USE_CUDSS=0
     export USE_SYSTEM_NVTX=1
     export MAGMA_HOME="${PREFIX}"
-    export CUDA_INC_PATH="${PREFIX}/targets/$(uname -m)-linux/include/"
+    # NVIDIA's conda CUDA packages use sbsa-linux (Server Base System Architecture)
+    # for aarch64, not aarch64-linux. uname -m returns "aarch64" which doesn't match.
+    case "$(uname -m)" in
+        aarch64) _cuda_arch="sbsa-linux" ;;
+        *)       _cuda_arch="$(uname -m)-linux" ;;
+    esac
+    export CUDA_INC_PATH="${PREFIX}/targets/${_cuda_arch}/include/"
     # pytorch 2.12 + CMake 4.x: cmake/public/cuda.cmake creates an INTERFACE
     # target caffe2::cuda → CUDA::cuda_driver, validated eagerly at generate.
-    # The driver stub from cuda-driver-dev lives under targets/<arch>-linux/lib/stubs/
+    # The driver stub from cuda-driver-dev lives under targets/<arch>/lib/stubs/
     # which FindCUDAToolkit doesn't search by default. Point cmake at it.
-    _arch="$(uname -m)"
-    export CMAKE_LIBRARY_PATH="${BUILD_PREFIX}/targets/${_arch}-linux/lib/stubs:${PREFIX}/targets/${_arch}-linux/lib/stubs:${CMAKE_LIBRARY_PATH}"
-    export CUDA_cuda_driver_LIBRARY="${BUILD_PREFIX}/targets/${_arch}-linux/lib/stubs/libcuda.so"
+    export CMAKE_LIBRARY_PATH="${BUILD_PREFIX}/targets/${_cuda_arch}/lib/stubs:${PREFIX}/targets/${_cuda_arch}/lib/stubs:${CMAKE_LIBRARY_PATH}"
+    export CUDA_cuda_driver_LIBRARY="${BUILD_PREFIX}/targets/${_cuda_arch}/lib/stubs/libcuda.so"
     # pytorch 2.12 still calls find_package(CUB) when CUDA<13 (Dependencies.cmake:1167).
     # FindCUB.cmake's HINTS=${CUDAToolkit_INCLUDE_DIRS} doesn't resolve to conda's
     # targets/<arch>-linux/include path, so it fails to find cub/cub.cuh even though
@@ -314,7 +319,7 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     # No-op for CUDA 13+, which doesn't call find_package(CUB).
     if [[ ${cuda_compiler_version} == 12.* ]] && [[ -f cmake/Modules/FindCUB.cmake ]]; then
         sed -i.bak \
-            's|HINTS "${CUDAToolkit_INCLUDE_DIRS}"|HINTS "${CUDAToolkit_INCLUDE_DIRS}" "'"${PREFIX}/targets/${_arch}-linux/include"'"|' \
+            's|HINTS "${CUDAToolkit_INCLUDE_DIRS}"|HINTS "${CUDAToolkit_INCLUDE_DIRS}" "'"${PREFIX}/targets/${_cuda_arch}/include"'"|' \
             cmake/Modules/FindCUB.cmake
     fi
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -298,6 +298,16 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     _arch="$(uname -m)"
     export CMAKE_LIBRARY_PATH="${BUILD_PREFIX}/targets/${_arch}-linux/lib/stubs:${PREFIX}/targets/${_arch}-linux/lib/stubs:${CMAKE_LIBRARY_PATH}"
     export CUDA_cuda_driver_LIBRARY="${BUILD_PREFIX}/targets/${_arch}-linux/lib/stubs/libcuda.so"
+    # pytorch 2.12 still calls find_package(CUB) when CUDA<13 (Dependencies.cmake:1167).
+    # FindCUB.cmake's HINTS=${CUDAToolkit_INCLUDE_DIRS} doesn't resolve to conda's
+    # targets/<arch>-linux/include path, so it fails to find cub/cub.cuh even though
+    # cuda-cccl_linux-64 shipped it there. Inject the path as an extra HINTS entry.
+    # No-op for CUDA 13+, which doesn't call find_package(CUB).
+    if [[ ${cuda_compiler_version} == 12.* ]] && [[ -f cmake/Modules/FindCUB.cmake ]]; then
+        sed -i.bak \
+            's|HINTS "${CUDAToolkit_INCLUDE_DIRS}"|HINTS "${CUDAToolkit_INCLUDE_DIRS}" "'"${PREFIX}/targets/${_arch}-linux/include"'"|' \
+            cmake/Modules/FindCUB.cmake
+    fi
 else
     # MKLDNN is an Apache-2.0 licensed library for DNNs and is used
     # for CPU builds. Not to be confused with MKL.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -271,10 +271,15 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     # Cap glibc per-thread malloc arenas so long-running cicc/gcc processes
     # don't hold hundreds of MB of fragmented heap. No codegen impact.
     export MALLOC_ARENA_MAX=2
-    # Serialize fbgemm_genai compiles via a dedicated Ninja job pool (patch
-    # 0024). Set as env vars so PyTorch setup.py auto-forwards them as -D
+    # Cap fbgemm_genai (CUTLASS) parallelism via a dedicated Ninja job pool
+    # (patch 0024). cutlass_heavy=4 lets 4 heavy CUTLASS TUs compile at once;
+    # observed RSS per cicc on g4dn.4xlarge T4 is ~4 GB, so 4× = ~16 GB peak,
+    # well under the 64 GB host budget. Was 1 (serialized) — that left 56 GB
+    # of RAM idle while MSLK FP4 GEMM kernels and fbgemm_genai TUs (8–9
+    # arches × heavy templates) dominated wall time.
+    # Set as env vars so PyTorch setup.py auto-forwards them as -D
     # (CMAKE_ARGS itself is not read by setup.py).
-    export CMAKE_JOB_POOLS="cutlass_heavy=1;compile=${MAX_JOBS};link=2"
+    export CMAKE_JOB_POOLS="cutlass_heavy=4;compile=${MAX_JOBS};link=2"
     export USE_FBGEMM_GENAI_JOB_POOL=cutlass_heavy
     export NCCL_ROOT_DIR=$PREFIX
     export NCCL_INCLUDE_DIR=$PREFIX/include

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -272,14 +272,18 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     # don't hold hundreds of MB of fragmented heap. No codegen impact.
     export MALLOC_ARENA_MAX=2
     # Cap fbgemm_genai (CUTLASS) parallelism via a dedicated Ninja job pool
-    # (patch 0024). cutlass_heavy=8 lets 8 heavy CUTLASS TUs compile at once;
-    # observed RSS per cicc on g4dn.4xlarge T4 is ~4 GB, so 8× = ~32 GB peak,
-    # roughly half the 64 GB host budget — still safe.
+    # (patch 0024). cutlass_heavy=4 lets 4 heavy CUTLASS TUs compile at once;
+    # observed RSS per cicc on g4dn.4xlarge T4 is ~4 GB, so 4× = ~16 GB peak,
+    # well under the 64 GB host budget. Was 1 originally (serialized) — that
+    # left 56 GB of RAM idle while MSLK FP4 GEMM kernels dominated wall time.
     # Measured speedup on the MSLK FP4 tail (cutlass_heavy=1 → 4): ~3.4×.
-    # Extrapolated 4 → 8 should buy another ~1.5–2× on the same tail.
+    # We tried =8 (PBP graph 2220751f): 13.0 dropped from 293→282 min (-3.8%),
+    # 12.9 went from 342→358 min (+4.7%) — net within noise floor. The MSLK
+    # tail saturates somewhere between 4 and 8 parallel TUs, so going higher
+    # adds memory pressure without real wall-time gains. Sticking with 4.
     # Set as env vars so PyTorch setup.py auto-forwards them as -D
     # (CMAKE_ARGS itself is not read by setup.py).
-    export CMAKE_JOB_POOLS="cutlass_heavy=8;compile=${MAX_JOBS};link=2"
+    export CMAKE_JOB_POOLS="cutlass_heavy=4;compile=${MAX_JOBS};link=2"
     export USE_FBGEMM_GENAI_JOB_POOL=cutlass_heavy
     export NCCL_ROOT_DIR=$PREFIX
     export NCCL_INCLUDE_DIR=$PREFIX/include

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -261,14 +261,22 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     if [[ "${target_platform}" != "${build_platform}" ]]; then
         export CUDA_TOOLKIT_ROOT=${PREFIX}
     fi
-    # TORCH_NVCC_FLAGS: --threads 2 parallelizes nvcc within each translation unit.
+    # TORCH_NVCC_FLAGS: --threads 1 (was 2) to bound nvcc internal parallelism per TU;
+    # combined with -Xptxas=--allow-expensive-optimizations=false to cap ptxas peak RAM
+    # on the CUTLASS-heavy fbgemm_genai TUs.
     # CUDA 13 also gets -compress-mode=size and BUILD_BUNDLE_PTXAS=1 (matches upstream
     # 2.12 .ci/manywheel/build_cuda.sh).
-    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all --threads 2"
+    export TORCH_NVCC_FLAGS="-Xfatbin -compress-all --threads 1 -Xptxas=--allow-expensive-optimizations=false"
     if [[ ${cuda_compiler_version} == 13.* ]]; then
         export TORCH_NVCC_FLAGS="${TORCH_NVCC_FLAGS} -compress-mode=size"
         export BUILD_BUNDLE_PTXAS=1
     fi
+    # OOM mitigation for fbgemm_genai (CUTLASS-heavy): pair patch 0024 with a Ninja
+    # job pool so only one cutlass_heavy TU compiles at a time. MALLOC_ARENA_MAX
+    # bounds glibc malloc arena fragmentation under heavy parallel nvcc.
+    export MALLOC_ARENA_MAX=2
+    export CMAKE_JOB_POOLS="cutlass_heavy=1;compile=${MAX_JOBS};link=2"
+    export USE_FBGEMM_GENAI_JOB_POOL=cutlass_heavy
     export NCCL_ROOT_DIR=$PREFIX
     export NCCL_INCLUDE_DIR=$PREFIX/include
     export USE_SYSTEM_NCCL=1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -237,20 +237,24 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     if [[ "${target_platform}" != "${build_platform}" ]]; then
         export CUDA_TOOLKIT_ROOT=${CUDA_HOME}
     fi
-    # CUDA arch lists aligned with upstream PyTorch v2.12.0 .ci/manywheel/build_cuda.sh.
+    # CUDA arch lists aligned with upstream PyTorch v2.12.0 .ci/manywheel/build_cuda.sh,
+    # with one deliberate divergence: keep trailing +PTX for forward-compat with future
+    # archs (sm_13+). Upstream 2.11 shipped +PTX; upstream 2.12 dropped it (line 112's
+    # comment still says "+ PTX for forward compatibility" but the code no longer adds it).
+    # We preserve +PTX so users on hardware newer than sm_12 still get JIT-runnable kernels.
     # 2.12 supports CUDA 12.6/12.8/12.9/13.0/13.2; we ship 12.9 and 13.0
     # (pkgs/main has cuda-nvcc 13.0 but not 13.2 yet — see CBC).
     if [[ "$target_platform" == "linux-aarch64" && ${cuda_compiler_version} == 13.* ]]; then
         # aarch64 CUDA 13: upstream filters out <8.0, 7.5, 8.6 (x86_64-only SKUs)
         # and adds sm_11.0 (Jetson Thor) only on aarch64.
         # Keeps 8.0 (A100), 9.0 (Grace Hopper), 10.0+12.0 (Blackwell), 11.0 (Thor).
-        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0"
+        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0+PTX"
     elif [[ ${cuda_compiler_version} == 12.* ]]; then
         # CUDA 12: sm_50-sm_61 deprecated in 12.8; sm_70 dropped upstream in 2.11.
-        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0"
+        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
     elif [[ ${cuda_compiler_version} == 13.* ]]; then
         # CUDA 13: sm_70 dropped; same arch list as 12.x for x86_64.
-        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0"
+        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
     else
         echo "No CUDA architecture list exists for CUDA v${cuda_compiler_version}"
         echo "in build.sh. Use https://en.wikipedia.org/wiki/CUDA#GPUs_supported to make one."

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -173,6 +173,17 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 else
     export CMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX${MACOSX_SDK_VERSION}.sdk"
     export CONDA_BUILD_SYSROOT="${CMAKE_OSX_SYSROOT}"
+    # SIR-3273 fix: the previous two exports were sufficient before the
+    # Taskcluster 95.x AMI rebuild because activation defaulted to the
+    # right SDK. After the rebuild, MacOSX.sdk symlink points at 12.1
+    # and activation pre-sets SDKROOT + CMAKE_ARGS to 12.1 too. clang
+    # honors SDKROOT and CMake honors -DCMAKE_OSX_SYSROOT= embedded in
+    # CMAKE_ARGS over our env overrides, so without these extra lines
+    # the compile still uses MacOSX12.1.sdk (which lacks Metal 3.0).
+    export SDKROOT="${CMAKE_OSX_SYSROOT}"
+    CMAKE_ARGS="${CMAKE_ARGS//MacOSX12.1.sdk/MacOSX${MACOSX_SDK_VERSION}.sdk}"
+    CMAKE_ARGS="${CMAKE_ARGS//-DCMAKE_OSX_DEPLOYMENT_TARGET=12.1/-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}}"
+    export CMAKE_ARGS
 fi
 
 # ============================================================

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -110,6 +110,60 @@ for ARG in $CMAKE_ARGS; do
 done
 unset CMAKE_INSTALL_PREFIX
 
+# ============================================================
+# SIR-3273 DIAGNOSTIC [block 1/3]: state BEFORE sysroot reconstruction
+# Captures what the compiler activation script handed us. Marek's
+# 2026-05-19 comment showed MacOSX14.5.sdk IS installed; the question
+# now is why downstream tooling picks 12.1 anyway.
+# ============================================================
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "===================================================================="
+    echo "SIR-3273 DIAGNOSTIC [1/3] — BEFORE sysroot reconstruction"
+    echo "===================================================================="
+    echo "[A] Installed SDKs on this worker (Marek showed 14.5 IS here):"
+    ls -la /Library/Developer/CommandLineTools/SDKs/ 2>&1 || true
+    echo
+    echo "[B] MacOSX*.sdk symlink resolution:"
+    for s in MacOSX.sdk MacOSX14.sdk MacOSX14.5.sdk MacOSX13.sdk MacOSX12.sdk MacOSX12.1.sdk; do
+        ls -la "/Library/Developer/CommandLineTools/SDKs/${s}" 2>&1 || true
+    done
+    echo
+    echo "[C] xcrun resolutions (what the toolchain auto-detects):"
+    echo "    xcrun --show-sdk-path:                  $(xcrun --show-sdk-path 2>&1 || echo FAIL)"
+    echo "    xcrun --show-sdk-version:               $(xcrun --show-sdk-version 2>&1 || echo FAIL)"
+    echo "    xcrun --sdk macosx --show-sdk-path:     $(xcrun --sdk macosx --show-sdk-path 2>&1 || echo FAIL)"
+    echo "    xcrun --sdk macosx14.5 --show-sdk-path: $(xcrun --sdk macosx14.5 --show-sdk-path 2>&1 || echo FAIL)"
+    echo "    xcode-select -p:                        $(xcode-select -p 2>&1 || echo FAIL)"
+    echo
+    echo "[D] CBC / activation env vars (pre-reconstruction state):"
+    echo "    CONDA_BUILD_SYSROOT:           ${CONDA_BUILD_SYSROOT:-<unset>}"
+    echo "    MACOSX_SDK_VERSION:            ${MACOSX_SDK_VERSION:-<unset>}"
+    echo "    MACOSX_DEPLOYMENT_TARGET:      ${MACOSX_DEPLOYMENT_TARGET:-<unset>}"
+    echo "    SDKROOT:                       ${SDKROOT:-<unset>}"
+    echo "    OSX_ARCH:                      ${OSX_ARCH:-<unset>}"
+    echo "    target_platform:               ${target_platform:-<unset>}"
+    echo "    build_platform:                ${build_platform:-<unset>}"
+    echo "    gpu_variant:                   ${gpu_variant:-<unset>}"
+    echo
+    echo "[E] Compiler env vars (set by activation):"
+    echo "    CC:                            ${CC:-<unset>}"
+    echo "    CXX:                           ${CXX:-<unset>}"
+    echo "    CFLAGS:                        ${CFLAGS:-<unset>}"
+    echo "    CXXFLAGS:                      ${CXXFLAGS:-<unset>}"
+    echo "    LDFLAGS:                       ${LDFLAGS:-<unset>}"
+    echo "    CMAKE_ARGS:                    ${CMAKE_ARGS:-<unset>}"
+    echo "    CMAKE_OSX_SYSROOT:             ${CMAKE_OSX_SYSROOT:-<unset>}"
+    echo "    CMAKE_OSX_DEPLOYMENT_TARGET:   ${CMAKE_OSX_DEPLOYMENT_TARGET:-<unset>}"
+    echo "    CMAKE_SYSROOT:                 ${CMAKE_SYSROOT:-<unset>}"
+    echo
+    echo "[F] clang resolution + version + default search paths:"
+    which clang || echo "    clang not in PATH"
+    clang --version 2>&1 | head -3 || true
+    echo "    -- clang -v -E -x c /dev/null (default search paths) --"
+    clang -v -E -x c /dev/null 2>&1 | head -40 || true
+    echo "===================================================================="
+fi
+
 # On macOS, the compiler activation overrides CONDA_BUILD_SYSROOT with the
 # base CBC's SDK (e.g. 12.1), and CMAKE_ARGS also carries that stale value.
 # Reconstruct the correct sysroot from MACOSX_SDK_VERSION, which is
@@ -119,6 +173,57 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 else
     export CMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX${MACOSX_SDK_VERSION}.sdk"
     export CONDA_BUILD_SYSROOT="${CMAKE_OSX_SYSROOT}"
+fi
+
+# ============================================================
+# SIR-3273 DIAGNOSTIC [block 2/3]: state AFTER sysroot reconstruction
+# Confirm the reconstruction set what we think it did, and inspect the
+# Metal headers in BOTH the reconstructed sysroot AND the 14.5 SDK
+# directly. If Metal headers in 14.5 SDK contain MTLLanguageVersion3_0
+# but the actual compile still fails on it, downstream tooling is
+# silently overriding our CMAKE_OSX_SYSROOT.
+# ============================================================
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "===================================================================="
+    echo "SIR-3273 DIAGNOSTIC [2/3] — AFTER sysroot reconstruction"
+    echo "===================================================================="
+    echo "[G] Env vars after reconstruction (lines 117-122):"
+    echo "    CONDA_BUILD_SYSROOT:           ${CONDA_BUILD_SYSROOT:-<unset>}"
+    echo "    CMAKE_OSX_SYSROOT:             ${CMAKE_OSX_SYSROOT:-<unset>}"
+    echo "    MACOSX_SDK_VERSION (driving):  ${MACOSX_SDK_VERSION:-<unset>}"
+    echo
+    echo "[H] Does CONDA_BUILD_SYSROOT contain Metal headers with MTLLanguageVersion3_0?"
+    METAL_HDR_DIR="${CONDA_BUILD_SYSROOT}/System/Library/Frameworks/Metal.framework/Headers"
+    if [ -d "${METAL_HDR_DIR}" ]; then
+        echo "    Metal.framework/Headers EXISTS at ${METAL_HDR_DIR}"
+        echo "    Sample headers:"
+        ls "${METAL_HDR_DIR}/" 2>&1 | head -8
+        echo "    grep MTLLanguageVersion3_0:"
+        grep -l "MTLLanguageVersion3_0" "${METAL_HDR_DIR}/"*.h 2>&1 | head -5 || echo "    NOT FOUND in CONDA_BUILD_SYSROOT"
+    else
+        echo "    Metal.framework/Headers MISSING at ${METAL_HDR_DIR}"
+    fi
+    echo
+    echo "[I] Cross-check the 14.5 SDK directly (Marek says it's installed):"
+    HDR_145="/Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk/System/Library/Frameworks/Metal.framework/Headers"
+    if [ -d "${HDR_145}" ]; then
+        echo "    14.5 Metal headers exist."
+        echo "    grep MTLLanguageVersion3_0 in 14.5 SDK Metal:"
+        grep -l "MTLLanguageVersion3_0" "${HDR_145}/"*.h 2>&1 | head -5 || echo "    NOT FOUND in 14.5 SDK"
+    else
+        echo "    14.5 Metal headers MISSING — Marek's evidence may not apply."
+    fi
+    echo
+    echo "[J] Same check on 12.1 SDK (the wrong one we keep falling back to):"
+    HDR_121="/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Metal.framework/Headers"
+    if [ -d "${HDR_121}" ]; then
+        echo "    grep MTLLanguageVersion3_0 in 12.1 SDK Metal:"
+        grep -l "MTLLanguageVersion3_0" "${HDR_121}/"*.h 2>&1 | head -5 || echo "    NOT FOUND in 12.1 SDK (expected — 12.1 predates Metal 3.0)"
+    fi
+    echo
+    echo "[K] What does clang now resolve as its default sysroot, with our overrides?"
+    clang -v -E -x c /dev/null 2>&1 | grep -iE "(sysroot|sdk)" | head -10 || true
+    echo "===================================================================="
 fi
 #export TH_BINARY_BUILD=1
 # Use our build version and number for inserting into binaries
@@ -332,6 +437,50 @@ fi
 
 echo '${CXX}'=${CXX}
 echo '${PREFIX}'=${PREFIX}
+
+# ============================================================
+# SIR-3273 DIAGNOSTIC [block 3/3]: final env right before build
+# Last chance to capture what's actually in env when setup.py /
+# pip starts. Anything overridden between blocks [2/3] and here is
+# from pytorch's own setup.py / CMake configure, not our recipe.
+# ============================================================
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "===================================================================="
+    echo "SIR-3273 DIAGNOSTIC [3/3] — FINAL env just before pip $PIP_ACTION"
+    echo "===================================================================="
+    echo "[L] Sysroot / SDK env at point of build invocation:"
+    echo "    CONDA_BUILD_SYSROOT:           ${CONDA_BUILD_SYSROOT:-<unset>}"
+    echo "    CMAKE_OSX_SYSROOT:             ${CMAKE_OSX_SYSROOT:-<unset>}"
+    echo "    CMAKE_OSX_DEPLOYMENT_TARGET:   ${CMAKE_OSX_DEPLOYMENT_TARGET:-<unset>}"
+    echo "    SDKROOT:                       ${SDKROOT:-<unset>}"
+    echo "    MACOSX_DEPLOYMENT_TARGET:      ${MACOSX_DEPLOYMENT_TARGET:-<unset>}"
+    echo "    MACOSX_SDK_VERSION:            ${MACOSX_SDK_VERSION:-<unset>}"
+    echo
+    echo "[M] Compiler invocation reality check:"
+    echo "    CC:                            ${CC:-<unset>}"
+    echo "    CXX:                           ${CXX:-<unset>}"
+    echo "    CFLAGS:                        ${CFLAGS:-<unset>}"
+    echo "    CXXFLAGS:                      ${CXXFLAGS:-<unset>}"
+    echo "    LDFLAGS:                       ${LDFLAGS:-<unset>}"
+    echo "    CMAKE_ARGS (may be stale):     ${CMAKE_ARGS:-<unset>}"
+    echo
+    echo "[N] What does the active clang resolve right now?"
+    ${CXX:-clang++} -v -E -x c++ /dev/null 2>&1 | grep -iE "(sysroot|sdk|Apple|target|Target)" | head -15 || true
+    echo
+    echo "[O] Compile-test: does \${CXX} with current flags see MTLLanguageVersion3_0?"
+    cat > /tmp/sir3273_metal_probe.mm <<'EOF'
+#include <Metal/Metal.h>
+int main() { return (int)MTLLanguageVersion3_0; }
+EOF
+    echo "    Trying compile probe with CXX + CXXFLAGS + LDFLAGS:"
+    ${CXX:-clang++} ${CXXFLAGS} ${LDFLAGS} -ObjC++ -fobjc-arc \
+        -framework Metal -framework Foundation \
+        /tmp/sir3273_metal_probe.mm -o /tmp/sir3273_metal_probe \
+        -v 2>&1 | grep -iE "(sysroot|sdk|MTLLanguageVersion3_0|error:)" | head -20 || true
+    rm -f /tmp/sir3273_metal_probe.mm /tmp/sir3273_metal_probe
+    echo "===================================================================="
+fi
+
 $PREFIX/bin/python -m pip $PIP_ACTION . --no-deps --no-build-isolation -vvv --no-clean \
     | sed "s,${CXX},\$\{CXX\},g" \
     | sed "s,${PREFIX},\$\{PREFIX\},g"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -272,14 +272,14 @@ elif [[ ${gpu_variant} == "cuda"* ]]; then
     # don't hold hundreds of MB of fragmented heap. No codegen impact.
     export MALLOC_ARENA_MAX=2
     # Cap fbgemm_genai (CUTLASS) parallelism via a dedicated Ninja job pool
-    # (patch 0024). cutlass_heavy=4 lets 4 heavy CUTLASS TUs compile at once;
-    # observed RSS per cicc on g4dn.4xlarge T4 is ~4 GB, so 4× = ~16 GB peak,
-    # well under the 64 GB host budget. Was 1 (serialized) — that left 56 GB
-    # of RAM idle while MSLK FP4 GEMM kernels and fbgemm_genai TUs (8–9
-    # arches × heavy templates) dominated wall time.
+    # (patch 0024). cutlass_heavy=8 lets 8 heavy CUTLASS TUs compile at once;
+    # observed RSS per cicc on g4dn.4xlarge T4 is ~4 GB, so 8× = ~32 GB peak,
+    # roughly half the 64 GB host budget — still safe.
+    # Measured speedup on the MSLK FP4 tail (cutlass_heavy=1 → 4): ~3.4×.
+    # Extrapolated 4 → 8 should buy another ~1.5–2× on the same tail.
     # Set as env vars so PyTorch setup.py auto-forwards them as -D
     # (CMAKE_ARGS itself is not read by setup.py).
-    export CMAKE_JOB_POOLS="cutlass_heavy=4;compile=${MAX_JOBS};link=2"
+    export CMAKE_JOB_POOLS="cutlass_heavy=8;compile=${MAX_JOBS};link=2"
     export USE_FBGEMM_GENAI_JOB_POOL=cutlass_heavy
     export NCCL_ROOT_DIR=$PREFIX
     export NCCL_INCLUDE_DIR=$PREFIX/include

--- a/recipe/build_libtorch.bat
+++ b/recipe/build_libtorch.bat
@@ -1,4 +1,8 @@
 @echo On
+@REM Workaround for SIR-3276 (post-Taskcluster 95.x AMI rebuild on win-64).
+@REM Without this per-output script entry conda-build inlines bld.bat into a
+@REM generated IF-block wrapper where %blas_impl% (and other CBC variant vars)
+@REM evaluate as empty strings — see meta.yaml libtorch output comment.
 setlocal enabledelayedexpansion
 
 call %RECIPE_DIR%\bld.bat

--- a/recipe/build_libtorch.bat
+++ b/recipe/build_libtorch.bat
@@ -1,0 +1,5 @@
+@echo On
+setlocal enabledelayedexpansion
+
+call %RECIPE_DIR%\bld.bat
+if errorlevel 1 exit /b 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,22 +6,22 @@ gpu_variant:
 blas_impl:                   # [win]
   - mkl                      # [win]
   - openblas                 # [win]
-# Linux aarch64 needs gcc 15.2.0 due to a bug with 14.3 with vector instructions
-c_compiler_version:          # [linux and aarch64]
+# Linux aarch64 needs gcc 15.2.0 due to a bug with 14.3 with vector instructions.
+# Linux x86_64 needs gcc 14 due to CUDA 12.x compatibility.
+c_compiler_version:
   - 15.2.0                   # [linux and aarch64]
-cxx_compiler_version:        # [linux and aarch64]
+  - 14                       # [linux and x86_64]
+cxx_compiler_version:
   - 15.2.0                   # [linux and aarch64]
-# Linux x86_64 needs gcc 14 due to CUDA 12.x compatibility
-c_compiler_version:          # [linux and x86_64]
   - 14                       # [linux and x86_64]
-cxx_compiler_version:        # [linux and x86_64]
-  - 14                       # [linux and x86_64]
-cuda_compiler_version:       # [win or (linux and x86_64)]
+# Upstream PyTorch v2.12.0 .ci/manywheel/build_cuda.sh supports 12.6/12.8/12.9/13.0/13.2.
+# pkgs/main currently ships cuda-nvcc 12.9 and 13.0 (no 13.2 yet).
+# Intersection: 12.9 and 13.0 — bump to 13.2 once cuda-nvcc 13.2 lands in pkgs/main.
+# aarch64 only supports CUDA 13.x (CUDA 12.x requires gcc <15, but aarch64 needs gcc 15.2.0).
+cuda_compiler_version:
   - 12.9                     # [win or (linux and x86_64)]
-  - 13.1                     # [win or (linux and x86_64)]
-# aarch64 only supports CUDA 13.x (CUDA 12.x requires gcc <15, but aarch64 needs gcc 15.2.0)
-cuda_compiler_version:       # [linux and aarch64]
-  - 13.1                     # [linux and aarch64]
+  - 13.0                     # [win or (linux and x86_64)]
+  - 13.0                     # [linux and aarch64]
 # CONDA_BUILD_SYSROOT is defined in the base cbc.yaml, but it's reflected here so we can zip the keys and
 # build GPU and CPU at the same time for osx-arm64. It'll need to be manually updated here if the base cbc is changed.
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,13 @@
+# gpu_variant is zipped with cuda_compiler_version on win/linux (so the CPU
+# variant doesn't duplicate across CUDA versions) and zipped with MACOSX_SDK /
+# CONDA_BUILD_SYSROOT on osx-arm64 (so CPU and Metal builds get separate SDKs).
+# The literal values cpu/metal/cuda are preserved for build-string selectors
+# (e.g. `cpu_{{ blas_impl }}_h…`, `gpu_cuda{{ cuda_compiler_version | replace }}_…`).
 gpu_variant:
-  - cpu
-  - metal                    # [(osx and arm64)]
-  - cuda                     # [win or linux]
+  - cpu                              # all platforms
+  - metal                            # [(osx and arm64)]
+  - cuda                             # [win or (linux and x86_64)]
+  - cuda                             # [win or linux]
 
 blas_impl:                   # [win]
   - mkl                      # [win]
@@ -18,10 +24,13 @@ cxx_compiler_version:
 # pkgs/main currently ships cuda-nvcc 12.9 and 13.0 (no 13.2 yet).
 # Intersection: 12.9 and 13.0 — bump to 13.2 once cuda-nvcc 13.2 lands in pkgs/main.
 # aarch64 only supports CUDA 13.x (CUDA 12.x requires gcc <15, but aarch64 needs gcc 15.2.0).
+# "none" pairs with gpu_variant=cpu/metal under zip_keys; the recipe ignores
+# cuda_compiler_version for non-CUDA variants but the key must align lengthwise.
 cuda_compiler_version:
-  - 12.9                     # [win or (linux and x86_64)]
-  - 13.0                     # [win or (linux and x86_64)]
-  - 13.0                     # [linux and aarch64]
+  - none                             # cpu
+  - none                             # [(osx and arm64)]  # metal pair
+  - 12.9                             # [win or (linux and x86_64)]
+  - 13.0                             # [win or linux]
 # CONDA_BUILD_SYSROOT is defined in the base cbc.yaml, but it's reflected here so we can zip the keys and
 # build GPU and CPU at the same time for osx-arm64. It'll need to be manually updated here if the base cbc is changed.
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.
@@ -32,10 +41,18 @@ MACOSX_SDK_VERSION:          # [(osx and arm64)]
 CONDA_BUILD_SYSROOT:         # [(osx and arm64)]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [(osx and arm64)]
-zip_keys:                    # [(osx and arm64)]
-  - gpu_variant              # [(osx and arm64)]
-  - MACOSX_SDK_VERSION       # [(osx and arm64)]
-  - CONDA_BUILD_SYSROOT      # [(osx and arm64)]
+# Two zip groups, gated by platform so the shared `gpu_variant` key doesn't conflict:
+#   - osx-arm64: zip gpu_variant with the two SDK keys (cpu↔13.3, metal↔14.5).
+#   - win/linux: zip gpu_variant with cuda_compiler_version so the CPU variant
+#                exists exactly once per platform (no Cartesian-product duplicates).
+zip_keys:
+  -                              # [(osx and arm64)]
+    - gpu_variant                # [(osx and arm64)]
+    - MACOSX_SDK_VERSION         # [(osx and arm64)]
+    - CONDA_BUILD_SYSROOT        # [(osx and arm64)]
+  -                              # [win or linux]
+    - gpu_variant                # [win or linux]
+    - cuda_compiler_version      # [win or linux]
 # megabuild is disabled as our CI runners work on each python version separately.
 megabuild:
 - false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,12 +3,27 @@
 # CONDA_BUILD_SYSROOT on osx-arm64 (so CPU and Metal builds get separate SDKs).
 # The literal values cpu/metal/cuda are preserved for build-string selectors
 # (e.g. `cpu_{{ blas_impl }}_h…`, `gpu_cuda{{ cuda_compiler_version | replace }}_…`).
+#
+# IMPORTANT: the two `cuda` entries are intentional and NOT a typo. They pair
+# row-wise with `cuda_compiler_version: [none, none, 12.9, 13.0]` via the
+# zip_keys block at the bottom of this file:
+#   entry 2 (selector: win or linux-x86_64)  pairs with cuda_compiler_version 12.9
+#   entry 3 (selector: win or linux)         pairs with cuda_compiler_version 13.0
+# linux-aarch64 only matches the second of the two cuda lines, so it builds
+# cuda 13.0 only (CUDA 12.x requires gcc <15 but aarch64 needs gcc 15.2.0).
 gpu_variant:
   - cpu                              # all platforms
   - metal                            # [(osx and arm64)]
   - cuda                             # [win or (linux and x86_64)]
   - cuda                             # [win or linux]
 
+# blas_impl is gated to [win] here because aggregate root CBC already defines
+# `mkl # [(x86 or x86_64) and not osx]` + `openblas` for the other platforms.
+# This block ADDS the Windows variants; non-Windows blas_impl is inherited
+# from aggregate (mkl on linux-x86_64, openblas on aarch64/osx). Note: per
+# conda-build's "local CBC REPLACES" rule the local entry would normally wipe
+# the aggregate value, but because the selector `[win]` only fires on Windows,
+# linux/osx see no local override and inherit normally.
 blas_impl:                   # [win]
   - mkl                      # [win]
   - openblas                 # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,19 @@
-{% set version = "2.11.0" %}
-{% set sha256 = "ab3fde9e7e382f45ac942be6ea2c2ef362c5ccd6f55ed6d5f35e6ea81d3ab88e" %}
-# Set the RC number to build release candidates. Set to None otherwise
-{% set rc = None %}
+{% set version = "2.12.0" %}
+{% set sha256 = "2d01cb1f6de449baa2880bc8242098240b0bdeb7abe2101dd9fb6e7c7d4b51de" %}
+# Set the RC number to build release candidates. Set to None otherwise.
+# When rc != None, the GitHub auto-archive tarball is used (submodules included).
+# At GA (~2026-05-13), set rc = None and bump sha256 to the official release
+# tarball (pytorch-v{{ version }}.tar.gz from the releases endpoint).
+{% set rc = "3" %}
 {% set build = 0 %}
 
 
 # Keep this in sync with the release
-{% set smoke_test_commit = "70d99e998b4955e0049d13a98d77ae1b14db1f45" %}
+{% set smoke_test_commit = "4bd029011e0cef6881f439fb244d0369a8942e40" %}
 
 # see https://github.com/pytorch/pytorch/blame/v{{ version }}/.ci/docker/ci_commit_pins/triton.txt
-{% set triton = "3.6.0" %}
+# 2.12 pins triton to release/3.7.x (commit b4e20bbe) — needs triton 3.7.0 in pkgs/main.
+{% set triton = "3.7.0" %}
 
 # Use a higher build number for the CUDA variant, to ensure that it's
 # preferred by conda's solver, and it's preferentially
@@ -34,16 +38,27 @@ package:
 
 source:
 {% if rc != None %}
-  # - git_url: https://github.com/pytorch/pytorch.git
-  #   git_rev: v{{ version.replace(".rc", "-rc") }}
-  # we cannot apply patches to submodules when checking out with git_url, because
-  # then conda switches the patch-application to use git, which cannot construct
-  # a usable ancestor from outside the submodule; the only option then is to
-  # pull in the submodules separately.
-  - url: https://github.com/pytorch/pytorch/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 04ae0a8babdc9cb9dfc4f8746b2b8aa0f8ed0f9e92835cc4af0bcb01e3969e51
+  # GitHub auto-archive tarball (includes vendored submodules — verified for v2.12.0-rc3).
+  # Patches apply against this tarball the same way as against the release tarball.
+  - url: https://github.com/pytorch/pytorch/archive/refs/tags/v{{ version }}-rc{{ rc }}.tar.gz
+    sha256: {{ sha256 }}
+    patches:
+      - patches/0001-windows-FindMKL-add-library-suffix.patch                  # [win]
+      - patches/0002-swap-openmp-search-precedence.patch                       # [blas_impl == "mkl"]
+      - patches/0003-Force-usage-of-python-3-and-error-without-numpy.patch
+      # https://github.com/pytorch/pytorch/issues/150918 - continue tests on failure due to flaky tests
+      - patches/0007-continue-tests-on-failure.patch
+      - patches/0008-add-missing-includes.patch
+      - patches/0009-use-prefix-include-for-inductor.patch
+      - patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch             # [win]
+      - patches/0014-point-include-paths-to-PREFIX-include.patch
+      - patches/0015-point-lib-paths-to-PREFIX-lib.patch
+      - patches/0018-Add-USE_SYSTEM-options-for-KLEIDI-CUDNN_FRONTEND-CUT.patch
+      - patches/0021-fix-onednn-cuda-include.patch
+      - patches/0022-force-bundled-mkldnn.patch
+      - patches/0023-remove-conftest-extra-param.patch
 {% else %}
-  # The "pytorch-v" tarballs contain submodules; the "pytorch-" ones don't.
+  # The "pytorch-v" release tarballs contain submodules; the "pytorch-" ones don't.
   - url: https://github.com/pytorch/pytorch/releases/download/v{{ version }}/pytorch-v{{ version }}.tar.gz
     sha256: {{ sha256 }}
     patches:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,8 +79,10 @@ source:
 {% endif %}
   - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.ci/pytorch/smoke_test/smoke_test.py
     folder: smoke_test
-  # The .gitignore is needed in order to run upstreams `setup.py clean`
-  - url: https://raw.githubusercontent.com/pytorch/pytorch/refs/tags/v{{ version }}/.gitignore
+  # The .gitignore is needed in order to run upstreams `setup.py clean`.
+  # Pin to smoke_test_commit so this works for both RC and GA; the v{{ version }}
+  # tag doesn't exist yet during pre-GA (rc != None).
+  - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.gitignore
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,11 +86,17 @@ source:
 
 build:
   number: {{ build }}
-  # Smoke build: restrict to win-64 CPU OpenBLAS / py3.13 only.
-  skip: true  # [not win]
-  skip: true  # [gpu_variant != "cpu"]
-  skip: true  # [blas_impl != "openblas"]
-  skip: true  # [py != 313]
+  # Skip ALL variants until 2.12.0 GA tarball ships (~2026-05-13).
+  # Reason: the rc3 GitHub auto-archive lacks vendored submodules
+  # (third_party/{pybind11,fmt,eigen,onnx,...} are empty placeholder dirs),
+  # so setup.py check_submodules() bails. Only releases/download/v{version}/
+  # pytorch-v{version}.tar.gz includes them, and that doesn't exist for RCs.
+  # At GA: set rc=None, bump sha256, then narrow back to stage-1 skip:
+  #   skip: true  # [not win]
+  #   skip: true  # [gpu_variant != "cpu"]
+  #   skip: true  # [blas_impl != "openblas"]
+  #   skip: true  # [py != 313]
+  skip: true
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                     # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,18 +86,16 @@ source:
 
 build:
   number: {{ build }}
-  # Stage-1 bootstrap: full platform coverage (win-64, linux-64, linux-aarch64
-  # CPU + CUDA), openblas + py3.13 only. Skip osx-arm64 (metal stage later),
-  # MKL, and non-py3.13.
+  # Stage-1 bootstrap: full platform coverage (win-64, linux-64, linux-aarch64,
+  # osx-arm64). openblas + py3.13 only — full BLAS + python matrices come in
+  # later stages.
   #
-  # On linux-aarch64 + CUDA we deliberately ship pytorch WITHOUT triton.
-  # PKG-13219: "we will deliver without triton on linux-aarch64. We don't
-  # want this to be blocking." triton is already gated to `linux and x86_64`
-  # in the run-deps below (and so is the inductor test block). 2.11 shipped
-  # aarch64 CUDA the same way. Pytorch builds cleanly without triton —
-  # torch.compile inductor backend is the only feature lost.
-  skip: true  # [osx]
-  skip: true  # [gpu_variant == "metal"]
+  # linux-aarch64 + CUDA: deliberately ships without triton per PKG-13219
+  # ("we will deliver without triton on linux-aarch64. We don't want this
+  # to be blocking."). triton is already gated to `linux and x86_64` in
+  # the run-deps below (and so is the inductor test block). 2.11 shipped
+  # aarch64 CUDA the same way — torch.compile inductor backend is the only
+  # feature lost.
   # CUDA: both 12.9 and 13.0 are enabled. PBP CUDA jobs hit a per-run
   # claim-expiry (~2h20m) and never complete (TaskCluster worker/service
   # version skew, SIR-3210), so CUDA builds happen on EC2 dev instances

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,9 +94,17 @@ build:
   skip: true  # [osx]
   skip: true  # [gpu_variant == "metal"]
   # CUDA: both 12.9 and 13.0 are enabled. PBP CUDA jobs hit a per-run
-  # timeout (~140 min) and never complete, so CUDA builds happen on EC2
-  # dev instances (see PR description). PBP-CUDA failures are expected
-  # until we can raise the per-run lease or fold the EC2 artifacts in.
+  # claim-expiry (~2h20m) and never complete (TaskCluster worker/service
+  # version skew, SIR-3210), so CUDA builds happen on EC2 dev instances
+  # (see PR description). PBP-CUDA failures are expected until the worker
+  # AMIs are bumped to match TaskCluster 95.1.4.
+  # win-64 + CUDA 12.9 hits a libcudacxx header bug:
+  #   clusterlaunchcontrol.h(191): error: asm operand type size(4) does not
+  #   match type/size implied by constraint 'l'
+  # The bug is in cuda-cccl_win-64 12.9.27's PTX intrinsic generator (fixed
+  # in 13.0). Skip win+12.9 until NVIDIA backports the fix or we patch
+  # the header locally.
+  skip: true  # [win and cuda_compiler_version == "12.9"]
   skip: true  # [blas_impl != "openblas"]
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.12.0" %}
-{% set sha256 = "7cc1deb309f402ad67e9f45bbe311a40def4db19d66fddb9b01950f9bfc5ccb1" %}
+{% set sha256 = "6a71b5f346cb08a6ae6fd63207c53a9bc7cae95dccfcd190bd9a43919f5f540a" %}
 # Set the RC number to build release candidates. Set to None otherwise.
 # When rc != None, the GitHub auto-archive tarball is used (submodules included).
 {% set rc = None %}
@@ -79,6 +79,14 @@ source:
 {% endif %}
   - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.ci/pytorch/smoke_test/smoke_test.py
     folder: smoke_test
+  # check_wheel_tags.py is a sibling helper imported by smoke_test.py since the
+  # 2.12 release (smoke_test.py:13 `from check_wheel_tags import …`). Without
+  # this file the win-64 pytorch test command `python ./smoke_test/smoke_test.py
+  # --package torchonly` fails with ModuleNotFoundError. The helper's runtime
+  # calls fall back to a "soft warn" mode when PYTORCH_FINAL_PACKAGE_DIR isn't
+  # set, so it works fine on conda-installed packages.
+  - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.ci/pytorch/smoke_test/check_wheel_tags.py
+    folder: smoke_test
   # The .gitignore is needed in order to run upstreams `setup.py clean`.
   # Pin to smoke_test_commit so this works for both RC and GA; the v{{ version }}
   # tag doesn't exist yet during pre-GA (rc != None).
@@ -86,36 +94,31 @@ source:
 
 build:
   number: {{ build }}
-  # Stage-1 bootstrap: full platform coverage (win-64, linux-64, linux-aarch64,
-  # osx-arm64). openblas + py3.13 only — full BLAS + python matrices come in
-  # later stages.
+  # Platform coverage at py3.14: linux-64 (cpu/cuda12.9/cuda13.0 × openblas/mkl
+  # = 6), linux-aarch64 (cpu + cuda13.0 × openblas = 2), osx-arm64 (cpu only;
+  # metal blocked, see below), win-64 (same 6 as linux-64). Total 15 builds.
+  # mkl is x86_64-only (aggregate CBC gates it via `(x86 or x86_64) and not
+  # osx`), so aarch64/osx stay on openblas automatically.
   #
   # linux-aarch64 + CUDA: deliberately ships without triton per PKG-13219
   # ("we will deliver without triton on linux-aarch64. We don't want this
-  # to be blocking."). triton is already gated to `linux and x86_64` in
-  # the run-deps below (and so is the inductor test block). 2.11 shipped
-  # aarch64 CUDA the same way — torch.compile inductor backend is the only
-  # feature lost.
-  # CUDA: both 12.9 and 13.0 are enabled. PBP CUDA jobs hit a per-run
-  # claim-expiry (~2h20m) and never complete (TaskCluster worker/service
-  # version skew, SIR-3210), so CUDA builds happen on EC2 dev instances
-  # (see PR description). PBP-CUDA failures are expected until the worker
-  # AMIs are bumped to match TaskCluster 95.1.4.
-  # win-64 + CUDA 12.9: previously hit a libcudacxx header bug
-  #   clusterlaunchcontrol.h(78): error: asm operand type size(4) does not
-  #   match type/size implied by constraint 'l'
-  # Worked around inline by bld.bat (sed-replace long2 → longlong2 in the
-  # affected header), so we no longer skip the variant.
-  # Stage-2: both BLAS impls now enabled. mkl is gated to x86_64 in the
-  # aggregate CBC, so this adds 6 builds at py3.13:
-  #   linux-64 (cpu_mkl, cuda12.9_mkl, cuda13.0_mkl) + win-64 (same 3) = 6
-  # linux-aarch64 and osx-arm64 stay on openblas (CBC gating).
-  # py3.14 sweep: switch from py3.13 to py3.14 to exercise the unverified
-  # dep matrix; py3.13 already validated in the previous CI run.
+  # to be blocking."). triton is gated to `linux and x86_64` in the run-deps
+  # below (and so is the inductor test block). 2.11 shipped aarch64 CUDA the
+  # same way — torch.compile inductor backend is the only feature lost.
+  # win-64 + CUDA 12.9: cuda-cccl_win-64 12.9.27 ships a libcudacxx
+  # clusterlaunchcontrol.h header with an asm-constraint bug on MSVC
+  # ("asm operand type size(4) does not match constraint 'l'"). Worked
+  # around inline by bld.bat (sed-replace long2 → longlong2 in the affected
+  # header); no skip needed.
+  # Per-Python skip: rotates each CI round. py3.13 was validated in graph
+  # 024f17c9 (round 1); this round runs py3.14 to catch deps that haven't
+  # been packaged for the new ABI. Flip back to a multi-py matrix (drop the
+  # skip entirely) before merging to master.
   skip: true  # [py != 314]
   # osx-arm64 metal: AMI rebuild dropped MacOSX14.5.sdk (SIR-3273); skip
   # the metal variant until SIR-3273 lands so we don't burn the slot on
   # a known-broken build. CPU variant keeps building.
+  # TODO: re-enable when SIR-3273 closes.
   skip: true  # [osx and arm64 and gpu_variant == "metal"]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,13 +94,10 @@ build:
   skip: true  # [aarch64]
   skip: true  # [osx]
   skip: true  # [gpu_variant == "metal"]
+  # Stage-1: only build CUDA 13.0 (the new toolchain). zip_keys means CPU
+  # appears exactly once per platform (cuda_compiler_version="none"), so no
+  # CPU dedup skip is needed.
   skip: true  # [gpu_variant == "cuda" and cuda_compiler_version == "12.9"]
-  # Without zip_keys, gpu_variant × cuda_compiler_version is a Cartesian product
-  # and the CPU variant gets duplicated once per CUDA version (cuda_compiler_version
-  # is irrelevant for CPU builds but still bumps PKG_HASH). Collapse to one CPU build
-  # per platform. A cleaner long-term fix is zip_keys-aligning gpu_variant with
-  # cuda_compiler_version (arrow-cpp / lightgbm pattern); tracked as a follow-up.
-  skip: true  # [gpu_variant == "cpu" and cuda_compiler_version == "12.9"]
   skip: true  # [blas_impl != "openblas"]
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
@@ -132,7 +129,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}                    # [(gpu_variant or "").startswith("cuda")]
     - cuda-version {{ cuda_compiler_version }}  # [(gpu_variant or "").startswith("cuda")]
-    - nvtx-c                                 # [cuda_compiler_version != "None" and build_platform != target_platform]
+    - nvtx-c                                 # [(gpu_variant or "").startswith("cuda") and build_platform != target_platform]
     {% if cuda_major >= 12 %}
     # pytorch 2.12 cmake/public/cuda.cmake:165 link-resolves CUDA::cuda_driver
     # at configure time; need the driver stub in build for native too, not

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,10 +87,16 @@ source:
 build:
   number: {{ build }}
   # Stage-1 bootstrap: minimum useful coverage — CPU + CUDA on win-64 and
-  # linux-64, openblas + py3.13 only. Skip aarch64 (triton 3.7 needs glibc
-  # 2.34, PBP runners are glibc 2.28 per PKG-13219), osx-arm64 (metal stage
-  # later), MKL, and non-py3.13.
-  skip: true  # [aarch64]
+  # linux-64, plus CPU on linux-aarch64; openblas + py3.13 only. Skip
+  # osx-arm64 (metal stage later), MKL, and non-py3.13.
+  #
+  # linux-aarch64 + CUDA is skipped because triton 3.7 (a CUDA-only runtime
+  # dep) needs glibc 2.34 and PBP aarch64 runners ship glibc 2.28 (see
+  # PKG-13219). CPU on aarch64 has no triton dep so it builds fine. 2.11
+  # shipped linux-aarch64 CUDA via triton 3.6, which didn't have the
+  # glibc 2.34 requirement — once PBP runners are bumped (or upstream
+  # backports the fix), we can drop the aarch64+cuda skip.
+  skip: true  # [aarch64 and (gpu_variant or "").startswith("cuda")]
   skip: true  # [osx]
   skip: true  # [gpu_variant == "metal"]
   # CUDA: both 12.9 and 13.0 are enabled. PBP CUDA jobs hit a per-run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,8 @@
 {% set version = "2.12.0" %}
-{% set sha256 = "2d01cb1f6de449baa2880bc8242098240b0bdeb7abe2101dd9fb6e7c7d4b51de" %}
+{% set sha256 = "7cc1deb309f402ad67e9f45bbe311a40def4db19d66fddb9b01950f9bfc5ccb1" %}
 # Set the RC number to build release candidates. Set to None otherwise.
 # When rc != None, the GitHub auto-archive tarball is used (submodules included).
-# At GA (~2026-05-13), set rc = None and bump sha256 to the official release
-# tarball (pytorch-v{{ version }}.tar.gz from the releases endpoint).
-{% set rc = "3" %}
+{% set rc = None %}
 {% set build = 0 %}
 
 
@@ -88,17 +86,14 @@ source:
 
 build:
   number: {{ build }}
-  # Skip ALL variants until 2.12.0 GA tarball ships (~2026-05-13).
-  # Reason: the rc3 GitHub auto-archive lacks vendored submodules
-  # (third_party/{pybind11,fmt,eigen,onnx,...} are empty placeholder dirs),
-  # so setup.py check_submodules() bails. Only releases/download/v{version}/
-  # pytorch-v{version}.tar.gz includes them, and that doesn't exist for RCs.
-  # At GA: set rc=None, bump sha256, then narrow back to stage-1 skip:
-  #   skip: true  # [not win]
-  #   skip: true  # [gpu_variant != "cpu"]
-  #   skip: true  # [blas_impl != "openblas"]
-  #   skip: true  # [py != 313]
-  skip: true
+  # Stage-1 bootstrap: build only win-64 + CPU + openblas + py3.13 to keep CI
+  # cheap while validating the 2.12 recipe. Expand to more variants once this
+  # passes (drop the [not win] line first → linux-64 CPU; then [gpu_variant !=
+  # "cpu"] → linux-64 CUDA; then [py != 313] for the full py3.10-3.14 matrix).
+  skip: true  # [not win]
+  skip: true  # [gpu_variant != "cpu"]
+  skip: true  # [blas_impl != "openblas"]
+  skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                     # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,13 @@ build:
   # aggregate CBC, so this adds 6 builds at py3.13:
   #   linux-64 (cpu_mkl, cuda12.9_mkl, cuda13.0_mkl) + win-64 (same 3) = 6
   # linux-aarch64 and osx-arm64 stay on openblas (CBC gating).
-  skip: true  # [py != 313]
+  # py3.14 sweep: switch from py3.13 to py3.14 to exercise the unverified
+  # dep matrix; py3.13 already validated in the previous CI run.
+  skip: true  # [py != 314]
+  # osx-arm64 metal: AMI rebuild dropped MacOSX14.5.sdk (SIR-3273); skip
+  # the metal variant until SIR-3273 lands so we don't burn the slot on
+  # a known-broken build. CPU variant keeps building.
+  skip: true  # [osx and arm64 and gpu_variant == "metal"]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                     # [gpu_variant == "cpu"]
@@ -278,6 +284,17 @@ test:
 
 outputs:
   - name: libtorch
+    # Workaround for a win-64 conda-build wrapping change post-Taskcluster 95.x
+    # AMI rebuild (SIR-3210 / SIR-3264): when libtorch has no per-output script,
+    # conda-build inlines the top-level bld.bat into a generated IF-block
+    # wrapper instead of calling it as its own batch process. Inside that
+    # wrapper, CBC variant variables like %blas_impl% are empty, so bld.bat's
+    # BLAS check fails and the libtorch .conda artifact ships with 0 files.
+    # Giving libtorch its own per-output script (mirroring pytorch's
+    # build_pytorch.bat -> bld.bat pattern) forces a separate batch invocation
+    # where %blas_impl% is correctly populated. unix is unaffected; the
+    # top-level build.sh continues to run for the libtorch output there.
+    script: build_libtorch.bat  # [win]
     build:
       missing_dso_whitelist:
         # The are dynamically loaded from %SP_DIR%\torch\lib\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,17 +86,16 @@ source:
 
 build:
   number: {{ build }}
-  # Stage-1 bootstrap: minimum useful coverage — CPU + CUDA on win-64 and
-  # linux-64, plus CPU on linux-aarch64; openblas + py3.13 only. Skip
-  # osx-arm64 (metal stage later), MKL, and non-py3.13.
+  # Stage-1 bootstrap: full platform coverage (win-64, linux-64, linux-aarch64
+  # CPU + CUDA), openblas + py3.13 only. Skip osx-arm64 (metal stage later),
+  # MKL, and non-py3.13.
   #
-  # linux-aarch64 + CUDA is skipped because triton 3.7 (a CUDA-only runtime
-  # dep) needs glibc 2.34 and PBP aarch64 runners ship glibc 2.28 (see
-  # PKG-13219). CPU on aarch64 has no triton dep so it builds fine. 2.11
-  # shipped linux-aarch64 CUDA via triton 3.6, which didn't have the
-  # glibc 2.34 requirement — once PBP runners are bumped (or upstream
-  # backports the fix), we can drop the aarch64+cuda skip.
-  skip: true  # [aarch64 and (gpu_variant or "").startswith("cuda")]
+  # On linux-aarch64 + CUDA we deliberately ship pytorch WITHOUT triton.
+  # PKG-13219: "we will deliver without triton on linux-aarch64. We don't
+  # want this to be blocking." triton is already gated to `linux and x86_64`
+  # in the run-deps below (and so is the inductor test block). 2.11 shipped
+  # aarch64 CUDA the same way. Pytorch builds cleanly without triton —
+  # torch.compile inductor backend is the only feature lost.
   skip: true  # [osx]
   skip: true  # [gpu_variant == "metal"]
   # CUDA: both 12.9 and 13.0 are enabled. PBP CUDA jobs hit a per-run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ source:
       - patches/0021-fix-onednn-cuda-include.patch
       - patches/0022-force-bundled-mkldnn.patch
       - patches/0023-remove-conftest-extra-param.patch
+      - patches/0024-Allow-fbgemm_genai-to-be-assigned-to-a-Ninja-job-pool.patch    # [linux and gpu_variant == "cuda"]
 {% else %}
   # The "pytorch-v" release tarballs contain submodules; the "pytorch-" ones don't.
   - url: https://github.com/pytorch/pytorch/releases/download/v{{ version }}/pytorch-v{{ version }}.tar.gz
@@ -76,6 +77,7 @@ source:
       - patches/0021-fix-onednn-cuda-include.patch
       - patches/0022-force-bundled-mkldnn.patch
       - patches/0023-remove-conftest-extra-param.patch
+      - patches/0024-Allow-fbgemm_genai-to-be-assigned-to-a-Ninja-job-pool.patch    # [linux and gpu_variant == "cuda"]
 {% endif %}
   - url: https://raw.githubusercontent.com/pytorch/pytorch/{{ smoke_test_commit }}/.ci/pytorch/smoke_test/smoke_test.py
     folder: smoke_test
@@ -186,7 +188,7 @@ requirements:
     - python       # [not megabuild]
     - numpy >=1.26.0,<3.0.0
     - pip
-    # pytorch 2.11 requirements.txt caps setuptools <82
+    # upstream requirements.txt caps setuptools <82
     - setuptools <82
     - wheel
     - pyyaml
@@ -204,10 +206,14 @@ requirements:
     - sleef 3.5.1
     - libuv
     - pkg-config  # [unix]
-    - typing_extensions
+    # upstream requirements-build.txt: typing-extensions>=4.15.0
+    - typing_extensions >=4.15.0
     - packaging
-    # https://github.com/pytorch/pytorch/pull/175115 caps pybind11 below 3.0.2
-    - pybind11 <3.0.2
+    # upstream pytorch 2.12 vendors pybind11 3.0.1 (third_party submodule).
+    # ABI-compatible up to 3.0.x; cap at 4.0 for future safety. pybind11-abi
+    # explicitly included to pin the ABI version (PKG-13552; mamba-feedstock pattern).
+    - pybind11 >=3.0.1,<4
+    - pybind11-abi
     - eigen {{ eigen }}
     - zlib {{ zlib }}
     - fmt {{ fmt }}
@@ -368,7 +374,7 @@ outputs:
         - python
         - numpy >=1.26.0,<3.0.0
         - pip
-        # pytorch 2.11 requirements.txt caps setuptools <82
+        # upstream requirements.txt caps setuptools <82
         - setuptools <82
         - wheel
         - pyyaml
@@ -386,11 +392,14 @@ outputs:
         - sleef 3.5.1
         - libuv
         - pkg-config  # [unix]
-        - typing_extensions
+        # upstream requirements-build.txt: typing-extensions>=4.15.0
+        - typing_extensions >=4.15.0
         - packaging
         - {{ pin_subpackage('libtorch', exact=True) }}
-        # https://github.com/pytorch/pytorch/pull/175115 caps pybind11 below 3.0.2
-        - pybind11 <3.0.2
+        # upstream pytorch 2.12 vendors pybind11 3.0.1; ABI-compatible up to 3.0.x.
+        # pybind11-abi explicit (PKG-13552, mamba pattern).
+        - pybind11 >=3.0.1,<4
+        - pybind11-abi
         - eigen {{ eigen }}
         - zlib {{ zlib }}
         - fmt {{ fmt }}
@@ -418,7 +427,7 @@ outputs:
         # Required to support torch.compile. This is tested in smoke_test.py, which is required to pass
         - triton =={{ triton }}       # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
         - {{ pin_subpackage('libtorch', exact=True) }}
-        # pytorch 2.11 requirements.txt caps setuptools <82
+        # upstream requirements.txt caps setuptools <82
         - setuptools <82
       run_constrained:
         # current intel-openmp builds are incompatible with llvm-openmp on osx-64
@@ -444,7 +453,7 @@ outputs:
         - pytest-flakefinder
         - pytest-xdist
         # Needed for test_autograd.py
-        - pybind11 <3.0.2
+        - pybind11 >=3.0.1,<4
         # the inductor "test_aoti_eager..." tests require objcopy
         - binutils  # [linux]
         # Triton JIT links cuda_utils.c against libcuda; use driver stubs from the env (no system /lib64 driver in many builders)
@@ -500,9 +509,14 @@ outputs:
         # (for example, in the case of missing imports). There doesn't seem to be a way of making a script exception return
         # non-zero but failing tests return zero.
         # ------------------------------------------------------------------------------------------------
-        # Exclude complex tests that are known to be flaky for -k "not (complex and (linalg_vecdot or dot or vdot))"
-        # https://github.com/pytorch/pytorch/issues/150918
-        - python ./test/run_test.py --core --continue-through-error -k "not (complex and (linalg_vecdot or dot or vdot))" || true # [not win]
+        # Flaky complex linear-algebra cases (see run_test_core_k); https://github.com/pytorch/pytorch/issues/150918
+        {% set run_test_core_k = "not (complex and (linalg_vecdot or dot or vdot))" %}
+        # On linux-aarch64 + CUDA, test_ops_gradients::test_inplace_gradgrad_* crashes
+        # consistently (segfault under ASAN-free build); exclude additionally on that
+        # variant only so the rest of --core still runs.
+        {% set run_test_core_k_aarch64_cuda = run_test_core_k ~ " and not inplace_gradgrad" %}
+        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k }}" || true # [not win and not (linux and aarch64 and (gpu_variant or "").startswith("cuda"))]
+        - python ./test/run_test.py --core --continue-through-error -k "{{ run_test_core_k_aarch64_cuda }}" || true # [linux and aarch64 and (gpu_variant or "").startswith("cuda")]
         # lgamma or mvlgamma or multigammaln or gammaln all have these issues on a combination of Intel Xeon processors and Windows Server differences.
         # enabling these tests on windows will cause numerical differences in the test suite.
         # This is a non-deterministic issue where between 80-110 tests fail. This has been observed between Pytorch 2.5 and above.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -116,16 +116,14 @@ build:
   # ("asm operand type size(4) does not match constraint 'l'"). Worked
   # around inline by bld.bat (sed-replace long2 → longlong2 in the affected
   # header); no skip needed.
-  # Per-Python skip: rotates each CI round. py3.13 was validated in graph
-  # 024f17c9 (round 1); this round runs py3.14 to catch deps that haven't
-  # been packaged for the new ABI. Flip back to a multi-py matrix (drop the
-  # skip entirely) before merging to master.
-  skip: true  # [py != 314]
-  # osx-arm64 metal: AMI rebuild dropped MacOSX14.5.sdk (SIR-3273); skip
-  # the metal variant until SIR-3273 lands so we don't burn the slot on
-  # a known-broken build. CPU variant keeps building.
-  # TODO: re-enable when SIR-3273 closes.
-  skip: true  # [osx and arm64 and gpu_variant == "metal"]
+  # DEBUG PR for SIR-3273: build ONLY osx-arm64 metal py3.12 so we can
+  # capture diagnostic output from a single failing variant. The metal
+  # build is expected to fail at compile (MTLLanguageVersion3_0 undeclared);
+  # the debug echo block in build.sh (just after the sysroot reconstruction)
+  # captures the SDK selection state in the TaskCluster log so we can tell
+  # Marek which SDK is actually being picked at compile time and why.
+  # See SIR-3273 for context; this PR is sibling to #97/#101/#102.
+  skip: true  # [not (osx and arm64 and gpu_variant == "metal" and py == 312)]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                     # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,13 +98,11 @@ build:
   # version skew, SIR-3210), so CUDA builds happen on EC2 dev instances
   # (see PR description). PBP-CUDA failures are expected until the worker
   # AMIs are bumped to match TaskCluster 95.1.4.
-  # win-64 + CUDA 12.9 hits a libcudacxx header bug:
-  #   clusterlaunchcontrol.h(191): error: asm operand type size(4) does not
+  # win-64 + CUDA 12.9: previously hit a libcudacxx header bug
+  #   clusterlaunchcontrol.h(78): error: asm operand type size(4) does not
   #   match type/size implied by constraint 'l'
-  # The bug is in cuda-cccl_win-64 12.9.27's PTX intrinsic generator (fixed
-  # in 13.0). Skip win+12.9 until NVIDIA backports the fix or we patch
-  # the header locally.
-  skip: true  # [win and cuda_compiler_version == "12.9"]
+  # Worked around inline by bld.bat (sed-replace long2 → longlong2 in the
+  # affected header), so we no longer skip the variant.
   skip: true  # [blas_impl != "openblas"]
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,11 @@
 {% set version = "2.12.0" %}
-{% set sha256 = "6a71b5f346cb08a6ae6fd63207c53a9bc7cae95dccfcd190bd9a43919f5f540a" %}
+# sha256 matches the GA release tarball content that was published 2026-05-13.
+# GitHub silently regenerated the release asset between 2026-05-13 and 2026-05-15:
+# a fresh download today returns 6a71b5f346cb08a6ae6fd63207c53a9bc7cae95dccfcd190bd9a43919f5f540a.
+# PBP workers cached the original tarball (sha 7cc1deb) when the GA flip landed,
+# so we keep this sha to match the cache. TODO: pin to git_url + commit for
+# bit-exact reproducibility, or invalidate PBP source cache and bump to 6a71b5f.
+{% set sha256 = "7cc1deb309f402ad67e9f45bbe311a40def4db19d66fddb9b01950f9bfc5ccb1" %}
 # Set the RC number to build release candidates. Set to None otherwise.
 # When rc != None, the GitHub auto-archive tarball is used (submodules included).
 {% set rc = None %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,6 +95,12 @@ build:
   skip: true  # [osx]
   skip: true  # [gpu_variant == "metal"]
   skip: true  # [gpu_variant == "cuda" and cuda_compiler_version == "12.9"]
+  # Without zip_keys, gpu_variant × cuda_compiler_version is a Cartesian product
+  # and the CPU variant gets duplicated once per CUDA version (cuda_compiler_version
+  # is irrelevant for CPU builds but still bumps PKG_HASH). Collapse to one CPU build
+  # per platform. A cleaner long-term fix is zip_keys-aligning gpu_variant with
+  # cuda_compiler_version (arrow-cpp / lightgbm pattern); tracked as a follow-up.
+  skip: true  # [gpu_variant == "cpu" and cuda_compiler_version == "12.9"]
   skip: true  # [blas_impl != "openblas"]
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
@@ -128,7 +134,10 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}  # [(gpu_variant or "").startswith("cuda")]
     - nvtx-c                                 # [cuda_compiler_version != "None" and build_platform != target_platform]
     {% if cuda_major >= 12 %}
-    - cuda-driver-dev                        # [linux and build_platform != target_platform]
+    # pytorch 2.12 cmake/public/cuda.cmake:165 link-resolves CUDA::cuda_driver
+    # at configure time; need the driver stub in build for native too, not
+    # just cross-compile.
+    - cuda-driver-dev                        # [linux and (gpu_variant or "").startswith("cuda")]
     - cuda-cudart-dev                        # [build_platform != target_platform]
     - cuda-cupti-dev                         # [build_platform != target_platform]
     - cuda-nvrtc-dev                         # [build_platform != target_platform]
@@ -316,7 +325,9 @@ outputs:
         - {{ compiler('cuda') }}                 # [(gpu_variant or "").startswith("cuda")]
         - nvtx-c                                 # [(gpu_variant or "").startswith("cuda") and build_platform != target_platform]
         {% if cuda_major >= 12 %}
-        - cuda-driver-dev                        # [linux and build_platform != target_platform]
+        # pytorch 2.12 cmake/public/cuda.cmake:165 link-resolves CUDA::cuda_driver
+        # at configure time; need the driver stub in build for native too.
+        - cuda-driver-dev                        # [linux and (gpu_variant or "").startswith("cuda")]
         - cuda-cudart-dev                        # [build_platform != target_platform]
         - cuda-cupti-dev                         # [build_platform != target_platform]
         - cuda-nvrtc-dev                         # [build_platform != target_platform]
@@ -353,7 +364,9 @@ outputs:
         - magma                           # [(gpu_variant or "").startswith("cuda")]
         - nvtx-c                          # [(gpu_variant or "").startswith("cuda")]
         {% if cuda_major >= 12 %}
-        - cuda-driver-dev                 # [linux and build_platform != target_platform]
+        # pytorch 2.12 cmake/public/cuda.cmake:165 needs CUDA::cuda_driver at
+        # configure time; ship the driver stub on all linux CUDA hosts.
+        - cuda-driver-dev                 # [linux and (gpu_variant or "").startswith("cuda")]
         - cuda-cudart-dev
         - cuda-cupti-dev
         - cuda-nvrtc-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -173,6 +173,11 @@ requirements:
     - nccl                   # [(gpu_variant or "").startswith("cuda") and linux]
     {% endif %}
     {% if cuda_major >= 12 %}
+    # cuda-driver-dev ships libcuda.so stub under targets/<arch>-linux/lib/stubs/;
+    # cmake's FindCUDAToolkit searches under the host prefix, so the driver
+    # stub must be in host (not just build) for pytorch 2.12 cuda.cmake to
+    # resolve CUDA::cuda_driver.
+    - cuda-driver-dev                        # [linux]
     - cuda-cudart-dev
     - cuda-cupti-dev
     - cuda-nvrtc-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,12 +86,15 @@ source:
 
 build:
   number: {{ build }}
-  # Stage-1 bootstrap: build only win-64 + CPU + openblas + py3.13 to keep CI
-  # cheap while validating the 2.12 recipe. Expand to more variants once this
-  # passes (drop the [not win] line first → linux-64 CPU; then [gpu_variant !=
-  # "cpu"] → linux-64 CUDA; then [py != 313] for the full py3.10-3.14 matrix).
-  skip: true  # [not win]
-  skip: true  # [gpu_variant != "cpu"]
+  # Stage-1 bootstrap: minimum useful coverage — CPU + CUDA on win-64 and
+  # linux-64, openblas + py3.13 only. Skip aarch64 (triton 3.7 needs glibc
+  # 2.34, PBP runners are glibc 2.28 per PKG-13219), osx-arm64 (metal stage
+  # later), CUDA 12.9 (only the new 13.0 toolchain for stage-1), MKL, and
+  # non-py3.13. Expand by removing skips one at a time once stage-1 is green.
+  skip: true  # [aarch64]
+  skip: true  # [osx]
+  skip: true  # [gpu_variant == "metal"]
+  skip: true  # [gpu_variant == "cuda" and cuda_compiler_version == "12.9"]
   skip: true  # [blas_impl != "openblas"]
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,7 +106,10 @@ build:
   #   match type/size implied by constraint 'l'
   # Worked around inline by bld.bat (sed-replace long2 → longlong2 in the
   # affected header), so we no longer skip the variant.
-  skip: true  # [blas_impl != "openblas"]
+  # Stage-2: both BLAS impls now enabled. mkl is gated to x86_64 in the
+  # aggregate CBC, so this adds 6 builds at py3.13:
+  #   linux-64 (cpu_mkl, cuda12.9_mkl, cuda13.0_mkl) + win-64 (same 3) = 6
+  # linux-aarch64 and osx-arm64 stay on openblas (CBC gating).
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: gpu_mps_h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -368,7 +368,11 @@ outputs:
         - cudnn                           # [(gpu_variant or "").startswith("cuda")]
         - nccl                            # [(gpu_variant or "").startswith("cuda") and linux]
         {% endif %}
-        - magma                           # [(gpu_variant or "").startswith("cuda")]
+        # pytorch 2.12 BatchLinearAlgebra.cpp:55-57 #errors out when
+        # MAGMA_VERSION_MINOR>=10 (deliberate guard — their AT_MAGMA_VERSION
+        # macro packs minor*10 and overflows). MAGMA 2.10.0 is on pkgs/main;
+        # cap to <2.10 until pytorch upstream rewrites the version macro.
+        - magma <2.10                     # [(gpu_variant or "").startswith("cuda")]
         - nvtx-c                          # [(gpu_variant or "").startswith("cuda")]
         {% if cuda_major >= 12 %}
         # pytorch 2.12 cmake/public/cuda.cmake:165 needs CUDA::cuda_driver at

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,15 +89,14 @@ build:
   # Stage-1 bootstrap: minimum useful coverage — CPU + CUDA on win-64 and
   # linux-64, openblas + py3.13 only. Skip aarch64 (triton 3.7 needs glibc
   # 2.34, PBP runners are glibc 2.28 per PKG-13219), osx-arm64 (metal stage
-  # later), CUDA 12.9 (only the new 13.0 toolchain for stage-1), MKL, and
-  # non-py3.13. Expand by removing skips one at a time once stage-1 is green.
+  # later), MKL, and non-py3.13.
   skip: true  # [aarch64]
   skip: true  # [osx]
   skip: true  # [gpu_variant == "metal"]
-  # Stage-1: only build CUDA 13.0 (the new toolchain). zip_keys means CPU
-  # appears exactly once per platform (cuda_compiler_version="none"), so no
-  # CPU dedup skip is needed.
-  skip: true  # [gpu_variant == "cuda" and cuda_compiler_version == "12.9"]
+  # CUDA: both 12.9 and 13.0 are enabled. PBP CUDA jobs hit a per-run
+  # timeout (~140 min) and never complete, so CUDA builds happen on EC2
+  # dev instances (see PR description). PBP-CUDA failures are expected
+  # until we can raise the per-run lease or fold the EC2 artifacts in.
   skip: true  # [blas_impl != "openblas"]
   skip: true  # [py != 313]
   string: gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -188,8 +188,8 @@ requirements:
     - python       # [not megabuild]
     - numpy >=1.26.0,<3.0.0
     - pip
-    # upstream requirements.txt caps setuptools <82
-    - setuptools <82
+    # upstream requirements-build.txt: setuptools>=70.1.0,<82
+    - setuptools >=70.1.0,<82
     - wheel
     - pyyaml
     - requests
@@ -374,8 +374,8 @@ outputs:
         - python
         - numpy >=1.26.0,<3.0.0
         - pip
-        # upstream requirements.txt caps setuptools <82
-        - setuptools <82
+        # upstream requirements-build.txt: setuptools>=70.1.0,<82
+        - setuptools >=70.1.0,<82
         - wheel
         - pyyaml
         - requests
@@ -427,8 +427,8 @@ outputs:
         # Required to support torch.compile. This is tested in smoke_test.py, which is required to pass
         - triton =={{ triton }}       # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
         - {{ pin_subpackage('libtorch', exact=True) }}
-        # upstream requirements.txt caps setuptools <82
-        - setuptools <82
+        # upstream requirements-build.txt: setuptools>=70.1.0,<82
+        - setuptools >=70.1.0,<82
       run_constrained:
         # current intel-openmp builds are incompatible with llvm-openmp on osx-64
         - llvm-openmp <0a0                # [(blas_impl == "mkl") and (osx and x86_64)]  

--- a/recipe/patches/0001-windows-FindMKL-add-library-suffix.patch
+++ b/recipe/patches/0001-windows-FindMKL-add-library-suffix.patch
@@ -9,10 +9,10 @@ This is required because our mdl-devel package contains libraries named like
  cmake/Modules/FindMKL.cmake | 15 +++++++++------
  1 file changed, 9 insertions(+), 6 deletions(-)
 
-diff --git a/cmake/Modules/FindMKL.cmake b/cmake/Modules/FindMKL.cmake
-index 7c4647f3746..ff24c9787ad 100644
---- a/cmake/Modules/FindMKL.cmake
-+++ b/cmake/Modules/FindMKL.cmake
+Index: pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
+===================================================================
+--- pytorch-2.12.0-rc3.orig/cmake/Modules/FindMKL.cmake
++++ pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
 @@ -124,6 +124,9 @@ ELSE(WIN32)
      ELSE()
        SET(mklthreads "mkl_intel_thread")
@@ -23,7 +23,7 @@ index 7c4647f3746..ff24c9787ad 100644
      ENDIF()
      SET(mklifaces  "intel")
    ENDIF (CMAKE_COMPILER_IS_GNUCC)
-@@ -273,7 +276,7 @@ MACRO(CHECK_ALL_LIBRARIES LIBRARIES OPENMP_TYPE OPENMP_LIBRARY _name _list _flag
+@@ -273,7 +276,7 @@ MACRO(CHECK_ALL_LIBRARIES LIBRARIES OPEN
            ENDIF(OPENMP_FOUND)
          ELSEIF(${_library} MATCHES "iomp")
            SET(_openmp_type "Intel")
@@ -61,6 +61,3 @@ index 7c4647f3746..ff24c9787ad 100644
          MARK_AS_ADVANCED(MKL_CDFT_LIBRARIES)
        ENDIF (NOT MKL_CDFT_LIBRARIES)
      ENDFOREACH(mkls)
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0002-swap-openmp-search-precedence.patch
+++ b/recipe/patches/0002-swap-openmp-search-precedence.patch
@@ -6,10 +6,10 @@ Subject: [PATCH 02/13] Swap OpenMP search precedence to prefer Intel over GNU
  cmake/Modules/FindMKL.cmake | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/cmake/Modules/FindMKL.cmake b/cmake/Modules/FindMKL.cmake
-index ff24c9787ad..797cb4c25e8 100644
---- a/cmake/Modules/FindMKL.cmake
-+++ b/cmake/Modules/FindMKL.cmake
+Index: pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
+===================================================================
+--- pytorch-2.12.0-rc3.orig/cmake/Modules/FindMKL.cmake
++++ pytorch-2.12.0-rc3/cmake/Modules/FindMKL.cmake
 @@ -113,8 +113,8 @@ ELSE(WIN32)
        SET(mklthreads "mkl_tbb_thread")
        SET(mklrtls "tbb")
@@ -21,6 +21,3 @@ index ff24c9787ad..797cb4c25e8 100644
      ENDIF()
      SET(mklifaces  "intel" "gf")
    ELSE(CMAKE_COMPILER_IS_GNUCC)
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0003-Force-usage-of-python-3-and-error-without-numpy.patch
+++ b/recipe/patches/0003-Force-usage-of-python-3-and-error-without-numpy.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 01/16] Force usage of python 3 and error without numpy
  cmake/Dependencies.cmake | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index 903c212de81..ecf8669649b 100644
---- a/cmake/Dependencies.cmake
-+++ b/cmake/Dependencies.cmake
-@@ -818,9 +818,9 @@ if(BUILD_PYTHON)
+Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+===================================================================
+--- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
++++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+@@ -824,9 +824,9 @@ if(BUILD_PYTHON)
    if(USE_NUMPY)
      list(APPEND PYTHON_COMPONENTS NumPy)
    endif()
@@ -23,7 +23,7 @@ index 903c212de81..ecf8669649b 100644
  endif()
  
  if(NOT Python_Interpreter_FOUND)
-@@ -837,7 +837,7 @@ if(BUILD_PYTHON)
+@@ -843,7 +843,7 @@ if(BUILD_PYTHON)
    if(Python_Development.Module_FOUND)
      if(USE_NUMPY)
        if(NOT Python_NumPy_FOUND)

--- a/recipe/patches/0007-continue-tests-on-failure.patch
+++ b/recipe/patches/0007-continue-tests-on-failure.patch
@@ -6,19 +6,16 @@ Subject: [PATCH 04/13] Continue tests on failure
  test/run_test.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/test/run_test.py b/test/run_test.py
-index ac36d5db27e..c5f5f63779b 100755
---- a/test/run_test.py
-+++ b/test/run_test.py
-@@ -1244,7 +1244,7 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
+Index: pytorch-2.12.0-rc3/test/run_test.py
+===================================================================
+--- pytorch-2.12.0-rc3.orig/test/run_test.py
++++ pytorch-2.12.0-rc3/test/run_test.py
+@@ -1271,7 +1271,7 @@ def get_pytest_args(options, is_cpp_test
      else:
-         # When under the normal mode, retry a failed test 2 more times. -x means stop at the first
-         # failure
--        rerun_options = ["-x", "--reruns=2"]
-+        rerun_options = ["--reruns=2"]
+         # When under the normal mode, retry a failed test NUM_PYTEST_RERUNS more times.
+         # -x means stop at the first failure. Set PYTORCH_NUM_PYTEST_RERUNS=0 to disable.
+-        rerun_options = ["-x", f"--reruns={NUM_PYTEST_RERUNS}"]
++        rerun_options = [f"--reruns={NUM_PYTEST_RERUNS}"]
  
      pytest_args = [
          "-vv",
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0008-add-missing-includes.patch
+++ b/recipe/patches/0008-add-missing-includes.patch
@@ -11,10 +11,10 @@ case, they should be present.
  torch/csrc/distributed/c10d/control_plane/Handlers.hpp | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/torch/csrc/distributed/c10d/control_plane/Handlers.hpp b/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
-index 58ae9368ea2..a7dd16e1117 100644
---- a/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
-+++ b/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+Index: pytorch-2.12.0-rc3/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+===================================================================
+--- pytorch-2.12.0-rc3.orig/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
++++ pytorch-2.12.0-rc3/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
 @@ -4,6 +4,8 @@
  #include <map>
  #include <string>
@@ -24,6 +24,3 @@ index 58ae9368ea2..a7dd16e1117 100644
  
  #include <c10/macros/Export.h>
  
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0009-use-prefix-include-for-inductor.patch
+++ b/recipe/patches/0009-use-prefix-include-for-inductor.patch
@@ -17,11 +17,11 @@ and https://github.com/conda-forge/pytorch-cpu-feedstock/issues/447.
  torch/_inductor/cpp_builder.py | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)
 
-diff --git a/torch/_inductor/cpp_builder.py b/torch/_inductor/cpp_builder.py
-index e2cb445ed10..92513ea0c3d 100644
---- a/torch/_inductor/cpp_builder.py
-+++ b/torch/_inductor/cpp_builder.py
-@@ -1518,10 +1518,12 @@ def get_cpp_torch_options(
+Index: pytorch-2.12.0-rc3/torch/_inductor/cpp_builder.py
+===================================================================
+--- pytorch-2.12.0-rc3.orig/torch/_inductor/cpp_builder.py
++++ pytorch-2.12.0-rc3/torch/_inductor/cpp_builder.py
+@@ -1590,10 +1590,12 @@ def get_cpp_torch_options(
          + python_include_dirs
          + torch_include_dirs
          + omp_include_dir_paths
@@ -29,7 +29,7 @@ index e2cb445ed10..92513ea0c3d 100644
 +        + [sysconfig.get_config_var('prefix') + '/targets/@CUDA_TARGET@/include']
      )
      cflags = sys_libs_cflags + omp_cflags
-     ldflags = omp_ldflags
+     ldflags = sys_libs_ldflags + omp_ldflags
 -    libraries_dirs = python_libraries_dirs + torch_libraries_dirs + omp_lib_dir_paths
 +    libraries_dirs = python_libraries_dirs + torch_libraries_dirs + omp_lib_dir_paths + [sysconfig.get_config_var('prefix') + '/targets/@CUDA_TARGET@/lib/stubs']
      libraries = torch_libraries + omp_lib

--- a/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
+++ b/recipe/patches/0011-remove-DESTINATION-lib-from-CMake-install-TARGETS-di.patch
@@ -15,10 +15,10 @@ Suggested-By: Silvio Traversaro <silvio@traversaro.it>
  torch/lib/libshm_windows/CMakeLists.txt |  2 +-
  7 files changed, 16 insertions(+), 16 deletions(-)
 
-diff --git a/c10/CMakeLists.txt b/c10/CMakeLists.txt
-index f82e460cafc..d5df53938c3 100644
---- a/c10/CMakeLists.txt
-+++ b/c10/CMakeLists.txt
+Index: pytorch-2.12.0-rc3/c10/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/c10/CMakeLists.txt
++++ pytorch-2.12.0-rc3/c10/CMakeLists.txt
 @@ -162,7 +162,7 @@ if(NOT BUILD_LIBTORCHLESS)
    # Note: for now, we will put all export path into one single Caffe2Targets group
    # to deal with the cmake deployment need. Inside the Caffe2Targets set, the
@@ -28,11 +28,11 @@ index f82e460cafc..d5df53938c3 100644
  endif()
  
  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-diff --git a/c10/cuda/CMakeLists.txt b/c10/cuda/CMakeLists.txt
-index 2604f677858..dcad42167ea 100644
---- a/c10/cuda/CMakeLists.txt
-+++ b/c10/cuda/CMakeLists.txt
-@@ -83,7 +83,7 @@ if(NOT BUILD_LIBTORCHLESS)
+Index: pytorch-2.12.0-rc3/c10/cuda/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/c10/cuda/CMakeLists.txt
++++ pytorch-2.12.0-rc3/c10/cuda/CMakeLists.txt
+@@ -86,7 +86,7 @@ if(NOT BUILD_LIBTORCHLESS)
  # Note: for now, we will put all export path into one single Caffe2Targets group
  # to deal with the cmake deployment need. Inside the Caffe2Targets set, the
  # individual libraries like libc10.so and libcaffe2.so are still self-contained.
@@ -41,10 +41,10 @@ index 2604f677858..dcad42167ea 100644
  
  endif()
  
-diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
-index ef24471dba8..a410383de27 100644
---- a/c10/hip/CMakeLists.txt
-+++ b/c10/hip/CMakeLists.txt
+Index: pytorch-2.12.0-rc3/c10/hip/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/c10/hip/CMakeLists.txt
++++ pytorch-2.12.0-rc3/c10/hip/CMakeLists.txt
 @@ -56,7 +56,7 @@ if(NOT BUILD_LIBTORCHLESS)
        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
@@ -54,11 +54,11 @@ index ef24471dba8..a410383de27 100644
    set(C10_HIP_LIB c10_hip)
  endif()
  
-diff --git a/c10/xpu/CMakeLists.txt b/c10/xpu/CMakeLists.txt
-index c2fa65ba35e..3a384395e4a 100644
---- a/c10/xpu/CMakeLists.txt
-+++ b/c10/xpu/CMakeLists.txt
-@@ -47,7 +47,7 @@ if(NOT BUILD_LIBTORCHLESS)
+Index: pytorch-2.12.0-rc3/c10/xpu/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/c10/xpu/CMakeLists.txt
++++ pytorch-2.12.0-rc3/c10/xpu/CMakeLists.txt
+@@ -49,7 +49,7 @@ if(NOT BUILD_LIBTORCHLESS)
        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
        $<INSTALL_INTERFACE:include>
        )
@@ -67,11 +67,11 @@ index c2fa65ba35e..3a384395e4a 100644
    set(C10_XPU_LIB c10_xpu)
    add_subdirectory(test)
  endif()
-diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index 6cbaecc5d2e..fa7107180ef 100644
---- a/caffe2/CMakeLists.txt
-+++ b/caffe2/CMakeLists.txt
-@@ -575,7 +575,7 @@ if(USE_CUDA)
+Index: pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/caffe2/CMakeLists.txt
++++ pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+@@ -571,7 +571,7 @@ if(USE_CUDA)
    endif()
  
    target_link_libraries(caffe2_nvrtc PRIVATE caffe2::nvrtc ${DELAY_LOAD_FLAGS})
@@ -80,7 +80,7 @@ index 6cbaecc5d2e..fa7107180ef 100644
    if(USE_NCCL)
      list(APPEND Caffe2_GPU_SRCS
        ${TORCH_SRC_DIR}/csrc/cuda/nccl.cpp)
-@@ -656,7 +656,7 @@ if(USE_ROCM)
+@@ -654,7 +654,7 @@ if(USE_ROCM)
    target_link_libraries(caffe2_nvrtc hip::amdhip64 hiprtc::hiprtc)
    target_include_directories(caffe2_nvrtc PRIVATE ${CMAKE_BINARY_DIR})
    target_compile_definitions(caffe2_nvrtc PRIVATE USE_ROCM __HIP_PLATFORM_AMD__)
@@ -89,7 +89,7 @@ index 6cbaecc5d2e..fa7107180ef 100644
  endif()
  
  if(NOT NO_API AND NOT BUILD_LITE_INTERPRETER)
-@@ -1056,7 +1056,7 @@ elseif(USE_CUDA)
+@@ -1065,7 +1065,7 @@ elseif(USE_CUDA)
      target_compile_definitions(torch_cuda PUBLIC USE_NVSHMEM)
      target_compile_definitions(torch_nvshmem PUBLIC USE_NVSHMEM)
      target_link_libraries(torch_cuda PRIVATE torch_nvshmem)
@@ -98,7 +98,7 @@ index 6cbaecc5d2e..fa7107180ef 100644
    else()
      message(STATUS "NVSHMEM not found, not building with NVSHMEM support.")
    endif()
-@@ -1119,7 +1119,7 @@ elseif(USE_CUDA)
+@@ -1128,7 +1128,7 @@ elseif(USE_CUDA)
            CUDA::culibos ${CMAKE_DL_LIBS})
      endif()
      set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/../aten/src/ATen/native/cuda/LinearAlgebraStubs.cpp PROPERTIES COMPILE_FLAGS "-DBUILD_LAZY_CUDA_LINALG")
@@ -107,7 +107,7 @@ index 6cbaecc5d2e..fa7107180ef 100644
    endif()
  
    if(USE_PRECOMPILED_HEADERS)
-@@ -1594,17 +1594,17 @@ endif()
+@@ -1672,17 +1672,17 @@ endif()
  
  caffe2_interface_library(torch torch_library)
  
@@ -130,7 +130,7 @@ index 6cbaecc5d2e..fa7107180ef 100644
  
  target_link_libraries(torch PUBLIC torch_cpu_library)
  
-@@ -1747,7 +1747,7 @@ if(BUILD_SHARED_LIBS)
+@@ -1825,7 +1825,7 @@ if(BUILD_SHARED_LIBS)
        target_link_libraries(torch_global_deps torch::nvtoolsext)
      endif()
    endif()
@@ -139,11 +139,11 @@ index 6cbaecc5d2e..fa7107180ef 100644
  endif()
  
  # ---[ Caffe2 HIP sources.
-diff --git a/torch/CMakeLists.txt b/torch/CMakeLists.txt
-index 3a3ca0f1236..0e2c682fd97 100644
---- a/torch/CMakeLists.txt
-+++ b/torch/CMakeLists.txt
-@@ -466,7 +466,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
+Index: pytorch-2.12.0-rc3/torch/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/torch/CMakeLists.txt
++++ pytorch-2.12.0-rc3/torch/CMakeLists.txt
+@@ -464,7 +464,7 @@ if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL
      set_target_properties(torch_python PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
  endif()
  
@@ -152,10 +152,10 @@ index 3a3ca0f1236..0e2c682fd97 100644
  
  # Generate torch/version.py from the appropriate CMake cache variables.
  if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-diff --git a/torch/lib/libshm_windows/CMakeLists.txt b/torch/lib/libshm_windows/CMakeLists.txt
-index df2a1064938..5fa15e6be31 100644
---- a/torch/lib/libshm_windows/CMakeLists.txt
-+++ b/torch/lib/libshm_windows/CMakeLists.txt
+Index: pytorch-2.12.0-rc3/torch/lib/libshm_windows/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/torch/lib/libshm_windows/CMakeLists.txt
++++ pytorch-2.12.0-rc3/torch/lib/libshm_windows/CMakeLists.txt
 @@ -19,7 +19,7 @@ target_include_directories(shm PRIVATE
  target_link_libraries(shm torch c10)
  
@@ -165,6 +165,3 @@ index df2a1064938..5fa15e6be31 100644
  install(FILES libshm.h DESTINATION "include")
  
  if(MSVC AND BUILD_SHARED_LIBS)
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0014-point-include-paths-to-PREFIX-include.patch
+++ b/recipe/patches/0014-point-include-paths-to-PREFIX-include.patch
@@ -13,11 +13,11 @@ torch_include_dirs parameter.
  torch/utils/cpp_extension.py | 19 +++++--------------
  1 file changed, 5 insertions(+), 14 deletions(-)
 
-diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
-index f29c382f0e3..3863ee0be52 100644
---- a/torch/utils/cpp_extension.py
-+++ b/torch/utils/cpp_extension.py
-@@ -1569,29 +1569,20 @@ def include_paths(device_type: str = "cpu", torch_include_dirs=True) -> list[str
+Index: pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+===================================================================
+--- pytorch-2.12.0-rc3.orig/torch/utils/cpp_extension.py
++++ pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+@@ -1620,29 +1620,20 @@ def include_paths(device_type: str = "cp
      """
      paths = []
      lib_include = os.path.join(_TORCH_PATH, 'include')
@@ -52,6 +52,3 @@ index f29c382f0e3..3863ee0be52 100644
      elif device_type == "xpu":
          paths.append(_join_sycl_home('include'))
          paths.append(_join_sycl_home('include', 'sycl'))
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0015-point-lib-paths-to-PREFIX-lib.patch
+++ b/recipe/patches/0015-point-lib-paths-to-PREFIX-lib.patch
@@ -10,11 +10,11 @@ that's where are sos/dlls are.
  torch/utils/cpp_extension.py | 13 ++++++++++++-
  1 file changed, 12 insertions(+), 1 deletion(-)
 
-diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
-index 3863ee0be52..49af1639052 100644
---- a/torch/utils/cpp_extension.py
-+++ b/torch/utils/cpp_extension.py
-@@ -40,7 +40,18 @@ SHARED_FLAG = '/DLL' if IS_WINDOWS else '-shared'
+Index: pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+===================================================================
+--- pytorch-2.12.0-rc3.orig/torch/utils/cpp_extension.py
++++ pytorch-2.12.0-rc3/torch/utils/cpp_extension.py
+@@ -40,7 +40,18 @@ SHARED_FLAG = '/DLL' if IS_WINDOWS else
  
  _HERE = os.path.abspath(__file__)
  _TORCH_PATH = os.path.dirname(os.path.dirname(_HERE))
@@ -34,6 +34,3 @@ index 3863ee0be52..49af1639052 100644
  
  
  SUBPROCESS_DECODE_ARGS = ('oem',) if IS_WINDOWS else ()
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0018-Add-USE_SYSTEM-options-for-KLEIDI-CUDNN_FRONTEND-CUT.patch
+++ b/recipe/patches/0018-Add-USE_SYSTEM-options-for-KLEIDI-CUDNN_FRONTEND-CUT.patch
@@ -15,11 +15,11 @@ PR: https://github.com/pytorch/pytorch/pull/166824
  cmake/Summary.cmake          |  4 +++
  4 files changed, 74 insertions(+), 18 deletions(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5304d054e84..a45da811631 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -487,6 +487,10 @@ option(USE_SYSTEM_BENCHMARK "Use system-provided google benchmark." OFF)
+Index: pytorch-2.12.0-rc3/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/CMakeLists.txt
++++ pytorch-2.12.0-rc3/CMakeLists.txt
+@@ -507,6 +507,10 @@ option(USE_SYSTEM_BENCHMARK "Use system-
  option(USE_SYSTEM_ONNX "Use system-provided onnx." OFF)
  option(USE_SYSTEM_XNNPACK "Use system-provided xnnpack." OFF)
  option(USE_SYSTEM_NVTX "Use system-provided nvtx." OFF)
@@ -30,7 +30,7 @@ index 5304d054e84..a45da811631 100644
  option(USE_GOLD_LINKER "Use ld.gold to link" OFF)
  if(USE_SYSTEM_LIBS)
    set(USE_SYSTEM_CPUINFO ON)
-@@ -506,6 +510,10 @@ if(USE_SYSTEM_LIBS)
+@@ -526,6 +530,10 @@ if(USE_SYSTEM_LIBS)
      set(USE_SYSTEM_NCCL ON)
    endif()
    set(USE_SYSTEM_NVTX ON)
@@ -41,11 +41,11 @@ index 5304d054e84..a45da811631 100644
  endif()
  
  # /Z7 override option When generating debug symbols, CMake default to use the
-diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 11eef8f508c..683488fd8a2 100644
---- a/aten/src/ATen/CMakeLists.txt
-+++ b/aten/src/ATen/CMakeLists.txt
-@@ -704,8 +704,21 @@ if(USE_CUDA AND NOT USE_ROCM)
+Index: pytorch-2.12.0-rc3/aten/src/ATen/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/aten/src/ATen/CMakeLists.txt
++++ pytorch-2.12.0-rc3/aten/src/ATen/CMakeLists.txt
+@@ -797,8 +797,21 @@ if(USE_CUDA AND NOT USE_ROCM)
    add_definitions(-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1)
    add_definitions(-DCUTLASS_ENABLE_SM90_EXTENDED_MMA_SHAPES=1)
    add_definitions(-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED)
@@ -69,11 +69,11 @@ index 11eef8f508c..683488fd8a2 100644
  
    if($ENV{ATEN_STATIC_CUDA})
      if(CUDA_VERSION VERSION_LESS_EQUAL 12.9)
-diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index d2168da264b..07cf3dec461 100644
---- a/cmake/Dependencies.cmake
-+++ b/cmake/Dependencies.cmake
-@@ -962,7 +962,14 @@ if(USE_CUDNN)
+Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+===================================================================
+--- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
++++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+@@ -956,7 +956,14 @@ if(USE_CUDNN)
    if(CUDNN_VERSION VERSION_LESS 8.5)
      message(FATAL_ERROR "PyTorch needs CuDNN-8.5 or above, but found ${CUDNN_VERSION}. Builds are still possible with `USE_CUDNN=0`")
    endif()
@@ -89,7 +89,7 @@ index d2168da264b..07cf3dec461 100644
    target_include_directories(torch::cudnn INTERFACE ${CUDNN_FRONTEND_INCLUDE_DIR})
  endif()
  
-@@ -1526,7 +1533,7 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1527,7 +1534,7 @@ if(NOT INTERN_BUILD_MOBILE)
      message("disabling MKLDNN because USE_MKLDNN is not set")
    endif()
  
@@ -98,7 +98,7 @@ index d2168da264b..07cf3dec461 100644
      set(TEMP_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
      set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
      set(AT_KLEIDIAI_ENABLED 1)
-@@ -1536,6 +1543,22 @@ if(NOT INTERN_BUILD_MOBILE)
+@@ -1537,6 +1544,22 @@ if(NOT INTERN_BUILD_MOBILE)
      list(APPEND Caffe2_DEPENDENCY_LIBS kleidiai)
      # Recover build options.
      set(BUILD_SHARED_LIBS ${TEMP_BUILD_SHARED_LIBS} CACHE BOOL "Build shared libs" FORCE)
@@ -121,7 +121,7 @@ index d2168da264b..07cf3dec461 100644
    endif()
  
    if(UNIX AND NOT APPLE)
-@@ -1589,22 +1612,30 @@ endif()
+@@ -1590,22 +1613,30 @@ endif()
  # This was the default behavior before version 12.0.0.
  # Since PyTorch C API depends on it, make it available for projects that
  # depend on PyTorch.
@@ -166,11 +166,11 @@ index d2168da264b..07cf3dec461 100644
  
  # ---[ Kineto
  # edge profiler depends on KinetoProfiler but it only does cpu
-diff --git a/cmake/Summary.cmake b/cmake/Summary.cmake
-index b6e2ce888dc..b6e6a65441d 100644
---- a/cmake/Summary.cmake
-+++ b/cmake/Summary.cmake
-@@ -81,7 +81,9 @@ function(caffe2_print_configuration_summary)
+Index: pytorch-2.12.0-rc3/cmake/Summary.cmake
+===================================================================
+--- pytorch-2.12.0-rc3.orig/cmake/Summary.cmake
++++ pytorch-2.12.0-rc3/cmake/Summary.cmake
+@@ -82,7 +82,9 @@ function(caffe2_print_configuration_summ
      message(STATUS "    USE_MEM_EFF_ATTENTION : ${USE_MEM_EFF_ATTENTION}")
      if(${USE_CUDNN})
        message(STATUS "    cuDNN version       : ${CUDNN_VERSION}")
@@ -180,7 +180,7 @@ index b6e2ce888dc..b6e6a65441d 100644
      if(${USE_CUSPARSELT})
        message(STATUS "    cuSPARSELt version  : ${CUSPARSELT_VERSION}")
      endif()
-@@ -159,6 +161,7 @@ function(caffe2_print_configuration_summary)
+@@ -161,6 +163,7 @@ function(caffe2_print_configuration_summ
    endif()
    if(${USE_KLEIDIAI})
      message(STATUS "  USE_KLEIDIAI          : ${USE_KLEIDIAI}")
@@ -188,7 +188,7 @@ index b6e2ce888dc..b6e6a65441d 100644
    endif()
    message(STATUS "  USE_PRIORITIZED_TEXT_FOR_LD : ${USE_PRIORITIZED_TEXT_FOR_LD}")
    message(STATUS "  USE_UCC               : ${USE_UCC}")
-@@ -191,6 +194,7 @@ function(caffe2_print_configuration_summary)
+@@ -197,6 +200,7 @@ function(caffe2_print_configuration_summ
      message(STATUS "    USE_VULKAN_FP16_INFERENCE    : ${USE_VULKAN_FP16_INFERENCE}")
      message(STATUS "    USE_VULKAN_RELAXED_PRECISION : ${USE_VULKAN_RELAXED_PRECISION}")
    endif()

--- a/recipe/patches/0021-fix-onednn-cuda-include.patch
+++ b/recipe/patches/0021-fix-onednn-cuda-include.patch
@@ -6,11 +6,11 @@ Subject: [PATCH 12/13] Force OneDNN headers for BOTH CPU and CUDA targets
  caffe2/CMakeLists.txt | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
-diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index fa7107180ef..3e2a1a09b75 100644
---- a/caffe2/CMakeLists.txt
-+++ b/caffe2/CMakeLists.txt
-@@ -2018,3 +2018,16 @@ if(MSVC)
+Index: pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+===================================================================
+--- pytorch-2.12.0-rc3.orig/caffe2/CMakeLists.txt
++++ pytorch-2.12.0-rc3/caffe2/CMakeLists.txt
+@@ -2104,3 +2104,16 @@ if(MSVC)
    endforeach()
  endif()
  endif()
@@ -27,6 +27,3 @@ index fa7107180ef..3e2a1a09b75 100644
 +  target_include_directories(torch_cuda PRIVATE "${PROJECT_SOURCE_DIR}/third_party/ideep/mkl-dnn/include")
 +  target_include_directories(torch_cuda PRIVATE "${PROJECT_BINARY_DIR}/third_party/ideep/mkl-dnn/include")
 +endif()
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0022-force-bundled-mkldnn.patch
+++ b/recipe/patches/0022-force-bundled-mkldnn.patch
@@ -7,11 +7,11 @@ Subject: [PATCH] Force bundled OneDNN build, enable experimental kernels, and
  cmake/Dependencies.cmake | 24 ++++++++++++++++--------
  1 file changed, 16 insertions(+), 8 deletions(-)
 
-diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index ef5c2fd4e97..4696cdd4505 100644
---- a/cmake/Dependencies.cmake
-+++ b/cmake/Dependencies.cmake
-@@ -1479,14 +1479,22 @@ if(NOT INTERN_BUILD_MOBILE)
+Index: pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+===================================================================
+--- pytorch-2.12.0-rc3.orig/cmake/Dependencies.cmake
++++ pytorch-2.12.0-rc3/cmake/Dependencies.cmake
+@@ -1522,14 +1522,22 @@ if(NOT INTERN_BUILD_MOBILE)
      endif()
    endif()
    if(USE_MKLDNN)
@@ -42,6 +42,3 @@ index ef5c2fd4e97..4696cdd4505 100644
    else()
      message("disabling MKLDNN because USE_MKLDNN is not set")
    endif()
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0023-remove-conftest-extra-param.patch
+++ b/recipe/patches/0023-remove-conftest-extra-param.patch
@@ -11,11 +11,11 @@ This fixes compatibility with pytest 9+.
  test/conftest.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/test/conftest.py b/test/conftest.py
-index dd26655b334..f47036b517a 100644
---- a/test/conftest.py
-+++ b/test/conftest.py
-@@ -229,7 +229,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
+Index: pytorch-2.12.0-rc3/test/conftest.py
+===================================================================
+--- pytorch-2.12.0-rc3.orig/test/conftest.py
++++ pytorch-2.12.0-rc3/test/conftest.py
+@@ -233,7 +233,7 @@ def pytest_terminal_summary(terminalrepo
  
  
  @pytest.hookimpl(tryfirst=True)
@@ -24,6 +24,3 @@ index dd26655b334..f47036b517a 100644
      if parent.config.getoption("--use-main-module"):
          mod = Module.from_parent(parent, path=module_path)
          mod._getobj = MethodType(lambda x: sys.modules["__main__"], mod)
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0024-Allow-fbgemm_genai-to-be-assigned-to-a-Ninja-job-pool.patch
+++ b/recipe/patches/0024-Allow-fbgemm_genai-to-be-assigned-to-a-Ninja-job-pool.patch
@@ -1,0 +1,40 @@
+From 67170d4e398c75e9ce912d6a078ac4a7fe70676b Mon Sep 17 00:00:00 2001
+From: Jamie Robertson <jamierobertsongames@gmail.com>
+Date: Thu, 23 Apr 2026 21:37:14 +0100
+Subject: [PATCH] Allow fbgemm_genai to be assigned to a Ninja job pool
+
+The CUTLASS-based f4f4bf16 / mx8mx8bf16 kernels in the MSLK/fbgemm_genai build target peak at multiple GB of RSS per nvcc invocation during cicc template instantiation and routinely OOM memory-constrained build hosts (~32GB runners). Globally throttling MAX_JOBS to work around this penalises the rest of the build, which is cheap by comparison.
+
+Expose an optional FBGEMM_GENAI_JOB_POOL CMake variable that, when set, tags the target with JOB_POOL_COMPILE so Ninja can serialize only these compiles via CMAKE_JOB_POOLS while the rest of the build continues at normal parallelism. When the variable is not set, upstream build behaviour is unchanged.
+---
+ aten/src/ATen/CMakeLists.txt | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index 5cc22852618..923af45327a 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -392,6 +392,20 @@ IF(USE_MSLK)
+ 
+     set_target_properties(mslk PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ 
++    # Optional: assign the mslk target to a dedicated Ninja job pool
++    # so downstream packagers can serialize the CUTLASS-heavy f4/mx8 compiles.
++    # These kernels can peak at multiple GB of RSS per nvcc invocation and OOM
++    # memory-constrained build hosts. The pool name supplied here must also be
++    # declared in CMAKE_JOB_POOLS by the caller (e.g.
++    # -DCMAKE_JOB_POOLS="cutlass_heavy=1;compile=6;link=2"
++    # -DUSE_FBGEMM_GENAI_JOB_POOL=cutlass_heavy).
++    # The USE_ prefix lets PyTorch's setup.py auto-forward the variable from
++    # the environment. When unset, upstream build behaviour is unchanged.
++    if(USE_FBGEMM_GENAI_JOB_POOL)
++      set_target_properties(mslk PROPERTIES
++        JOB_POOL_COMPILE "${USE_FBGEMM_GENAI_JOB_POOL}")
++    endif()
++
+     set(mslk_cuh
+       "${MSLK_SRCS}/cutlass/mx8mx8bf16_grouped/"
+       "${MSLK_SRCS}/cutlass/f4f4bf16_grouped/"
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
**Sibling debug PR.** Same `2.12-prep` recipe as #97/#101/#102, scoped to a single variant (osx-arm64 + metal + py3.12) to capture diagnostic output for SIR-3273 without burning the 75-build matrix.

**Destination channel:** _none — diagnostic only, DO NOT MERGE_

### Links

- [SIR-3273](https://anaconda.atlassian.net/browse/SIR-3273) — osx-arm64 worker picks MacOSX12.1.sdk instead of 14.5 after Taskcluster 95.x AMI rebuild
- Sibling PRs: #97 (py3.14), #101 (py3.10+3.11), #102 (py3.12+3.13)
- Marek's [2026-05-19 comment](https://anaconda.atlassian.net/browse/SIR-3273) shows `MacOSX14.5.sdk` IS installed on the worker — so the original "SDK missing" diagnosis was wrong. The root cause is now "something picks 12.1 even though 14.5 is present"

### What this PR adds

`recipe/build.sh` — three diagnostic blocks bracketing the existing sysroot reconstruction (lines 113-122 in `2.12-prep`):

| Block | When | Captures |
|---|---|---|
| [1/3] | BEFORE sysroot reconstruction | installed SDKs, MacOSX*.sdk symlink targets, xcrun resolutions, CBC env from activation, compiler env, clang default search paths |
| [2/3] | AFTER sysroot reconstruction | confirm `CONDA_BUILD_SYSROOT` / `CMAKE_OSX_SYSROOT` actually changed; probe whether reconstructed sysroot's `Metal.framework` has `MTLLanguageVersion3_0`; cross-check 14.5 vs 12.1 SDK Metal headers directly |
| [3/3] | FINAL just before `pip $PIP_ACTION` | final env at build invocation point; standalone Metal compile probe through `${CXX}` + `${CXXFLAGS}` + `${LDFLAGS}` to surface the exact `-isysroot` the toolchain actually uses (independent of pytorch's own CMake) |

`recipe/meta.yaml` — replaces the two existing skip lines with a single skip that allows only the target variant:

```yaml
skip: true  # [not (osx and arm64 and gpu_variant == "metal" and py == 312)]
```

### Expected outcome

Build still fails at the `MTLLanguageVersion3_0` undeclared-identifier compile error (same as #97). The three diagnostic blocks land in the TaskCluster log **first**, giving us a concrete env dump to share with Marek and narrow down whether:

1. `CONDA_BUILD_SYSROOT` / `CMAKE_OSX_SYSROOT` reconstruction is silently overridden by something downstream (pytorch's setup.py? CMake auto-detect via `xcrun`?), or
2. The reconstructed sysroot points at 14.5 correctly but the 14.5 SDK on this AMI has stale Metal headers (i.e., the SDK directory was preserved but its contents weren't), or
3. The `MACOSX_SDK_VERSION` env var isn't being propagated to the worker correctly, so reconstruction picks the wrong SDK string

### CI cost

1 build × 1 variant ≈ ~1.5h. Fails fast, low overhead.

### When this PR closes

After we share the diagnostic output with Marek on SIR-3273 and identify the root cause. **DO NOT MERGE** — the debug echos and skip-filter would clobber the main 2.12 matrix.

[SIR-3273]: https://anaconda.atlassian.net/browse/SIR-3273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ