### PR TITLE
Rebuild/osx 2.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set sha256 = "ab3fde9e7e382f45ac942be6ea2c2ef362c5ccd6f55ed6d5f35e6ea81d3ab88e" %}
 # Set the RC number to build release candidates. Set to None otherwise
 {% set rc = None %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 
 # Keep this in sync with the release


### PR DESCRIPTION
Previous OSX build was revoked via hotfix. Bump build number and build for osx only. 
