### PR TITLE
pytorch 2.12.0 republish (py3.12/3.13): skip libtorch + wrappers to clear PBP duplicate-name block

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,5 +5,18 @@ extra_labels_for_os:
 
 task_timeout: 72000
 
-# build_parameters:
-#  - "--no-test"
+# Republish PR: drop --skip-existing from PBP's default build options
+# (default: --skip-existing --error-overlinking --suppress-variables).
+# With the libtorch + pytorch-{cpu|gpu} wrapper outputs skipped at output
+# level, conda-build's --skip-existing precheck calls is_package_built on
+# the pytorch output BEFORE any finalize_metadata runs. is_package_built
+# queries the local public/ output folder as a channel, which has no
+# noarch/repodata.json yet, and conda 26.3 raises UnavailableInvalidChannel.
+# In the canonical PR #97 the first output (libtorch) was not skipped, so
+# its finalize_metadata seeded the local index before any is_package_built
+# call. With libtorch skipped here, drop --skip-existing — on a fresh
+# republish there's nothing to skip anyway. NB: this REPLACES (not appends
+# to) the default flag set.
+build_parameters:
+  - "--error-overlinking"
+  - "--suppress-variables"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -490,6 +490,15 @@ outputs:
         - libtorch =={{ version }}=cpu_{{ blas_impl }}_*_{{ PKG_BUILDNUM }}                                       # [gpu_variant == "cpu"]
         - libtorch =={{ version }}=gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_*_{{ PKG_BUILDNUM }}    # [(gpu_variant or "").startswith("cuda")]
         - libtorch =={{ version }}=gpu_mps_*_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
+        # Republish PR: libtorch_python links against libabseil + libprotobuf
+        # (see top-level host on lines 441-442). When libtorch is built as a
+        # sibling output (canonical PR #97), libabseil/libprotobuf's run_exports
+        # propagate through libtorch -> pytorch via pin_subpackage and
+        # conda-build's overlinking check is satisfied transitively. With
+        # libtorch installed from pkgs/main as a binary dep, the chain doesn't
+        # follow, so list them explicitly in pytorch's run.
+        - libabseil
+        - libprotobuf {{ libprotobuf }}
         # upstream requirements-build.txt: setuptools>=70.1.0,<82
         - setuptools >=70.1.0,<82
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,10 @@ build:
   # Matrix split across 3 sibling PRs (SIR-2711 /tmp limit); recipe identical,
   # only skip differs — #97 py3.14, #101 py3.10/3.11, #102 py3.12/3.13.
   # Drop skip on merge-to-master once all three green.
-  skip: true  # [py != 314]
+  # Republish PRs: #97's libtorch + pytorch-{cpu|gpu} wrappers are already on
+  # pkgs/main; this PR only republishes the pytorch (py-specific) output for
+  # py3.12/3.13. libtorch + wrappers are skipped at output level below.
+  skip: true  # [py != 312 and py != 313]
   # osx-arm64 metal: re-enabled after SIR-3273 root cause fix in build.sh
   # (export SDKROOT + CMAKE_ARGS sed for 12.1 → MACOSX_SDK_VERSION).
   # Verified on PR #103 debug graph 935c2593-eeac-41a8-8683-ec3e80f48478.
@@ -291,6 +294,11 @@ outputs:
     # artifact. Per-output script forces a separate batch invocation. (unix unaffected.)
     script: build_libtorch.bat  # [win]
     build:
+      # Republish PR: libtorch was already released by PR #97 (build-string has
+      # no py-token, so the filenames would be byte-identical and PBP rejects
+      # the duplicate). Skip packaging here; top-level build.sh still runs and
+      # populates $PREFIX so the pytorch output below can link against it.
+      skip: true
       missing_dso_whitelist:
         # The are dynamically loaded from %SP_DIR%\torch\lib\
         - "**/asmjit.dll"             # [win]
@@ -336,7 +344,9 @@ outputs:
       detect_binary_files_with_prefix: false
       run_exports:
         - {{ pin_subpackage('pytorch', max_pin='x.x') }}
-        - {{ pin_subpackage('libtorch', max_pin='x.x') }}
+        # Republish PR: libtorch is not built here (skipped above); pin to the
+        # version on pkgs/main from PR #97, mirroring max_pin='x.x' semantics.
+        - libtorch >={{ version }},<2.13.0a0
     script: build_pytorch.sh   # [unix]
     script: build_pytorch.bat  # [win]
     requirements:
@@ -439,7 +449,12 @@ outputs:
         # upstream requirements-build.txt: typing-extensions>=4.15.0
         - typing_extensions >=4.15.0
         - packaging
-        - {{ pin_subpackage('libtorch', exact=True) }}
+        # Republish PR: libtorch is not built here (skipped above); pin by
+        # variant + build_num to the matching libtorch released by PR #97.
+        # The wildcard hash collapses to exactly one published file per slot.
+        - libtorch =={{ version }}=cpu_{{ blas_impl }}_*_{{ PKG_BUILDNUM }}                                       # [gpu_variant == "cpu"]
+        - libtorch =={{ version }}=gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_*_{{ PKG_BUILDNUM }}    # [(gpu_variant or "").startswith("cuda")]
+        - libtorch =={{ version }}=gpu_mps_*_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
         # upstream pytorch 2.12 vendors pybind11 3.0.1; ABI-compatible up to 3.0.x.
         # pybind11-abi explicit (PKG-13552, mamba pattern).
         - pybind11 >=3.0.1,<4
@@ -471,7 +486,10 @@ outputs:
         - fsspec
         # Required to support torch.compile. This is tested in smoke_test.py, which is required to pass
         - triton =={{ triton }}       # [(gpu_variant or "").startswith("cuda") and (linux and x86_64)]
-        - {{ pin_subpackage('libtorch', exact=True) }}
+        # Republish PR: libtorch is on pkgs/main from PR #97; pin by variant + build_num.
+        - libtorch =={{ version }}=cpu_{{ blas_impl }}_*_{{ PKG_BUILDNUM }}                                       # [gpu_variant == "cpu"]
+        - libtorch =={{ version }}=gpu_cuda{{ cuda_compiler_version | replace('.', '') }}_*_{{ PKG_BUILDNUM }}    # [(gpu_variant or "").startswith("cuda")]
+        - libtorch =={{ version }}=gpu_mps_*_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
         # upstream requirements-build.txt: setuptools>=70.1.0,<82
         - setuptools >=70.1.0,<82
       run_constrained:
@@ -616,6 +634,11 @@ outputs:
         - test -f $PREFIX/lib/libtorch_python${SHLIB_EXT}     # [unix]
 
   - name: pytorch-{{ "cpu" if gpu_variant == "cpu" else "gpu" }}
+    build:
+      # Republish PR: the wrapper metapackage was already released by PR #97
+      # (build-string uses h1234567 placeholder, identical across all py).
+      # Skip to avoid duplicate-filename release blocker.
+      skip: true
     requirements:
       run:
         - pytorch ={{ version }}={{ "cpu" if gpu_variant == "cpu" else "gpu" }}* # NB pinning exact=True will also pin to the python version


### PR DESCRIPTION
## Background

PR #97 (py3.14) merged and released pytorch 2.12.0 to pkgs/main on 2026-06-03. PRs #101 (py3.10/3.11) and #102 (py3.12/3.13) merged at the same time but their release graphs (`3decbbdf-…` and `d11527a7-…`) staged successfully and then failed to publish because PBP rejects duplicate filenames.

Two output families have build strings with no `py{CONDA_PY}` token, so they collide with PR #97's already-published files:

- `libtorch` — build string is `gpu_cuda{ver}_h{PKG_HASH}_{N}` / `cpu_{blas}_h{PKG_HASH}_{N}` / `gpu_mps_h{PKG_HASH}_{N}` (no py token). libtorch is python-independent, so PKG_HASH is the same across PRs.
- `pytorch-{cpu|gpu}` wrapper — inherits the top-level build string which uses literal placeholder `h1234567` (verified on pkgs/main, e.g. `pytorch-cpu-2.12.0-cpu_mkl_h1234567_100.conda`).

The `pytorch` output itself uses `..._py{CONDA_PY}h{PKG_HASH}_{N}` and produces distinct filenames per py-version — those are the artifacts we still need to publish.

## What this PR does

Republishes ONLY the `pytorch` output for **py3.12 and py3.13**:

1. Top-level skip selector switched to `[py != 312 and py != 313]`.
2. `libtorch` output: `build.skip: true`. The top-level `build.sh` still runs and populates `$PREFIX` with the C++ libs, so `build_pytorch.sh` can still symlink them into `$SP_DIR/torch` — only the libtorch `.conda` packaging is suppressed.
3. `pytorch-{cpu|gpu}` wrapper output: `build.skip: true`.
4. `pytorch` host + run deps on libtorch: replaced `pin_subpackage('libtorch', exact=True)` with an explicit per-variant wildcard pin that lands on the libtorch already released by PR #97:
   ```
   - libtorch =={{ version }}=cpu_{{ blas_impl }}_*_{{ PKG_BUILDNUM }}                                       # [gpu_variant == "cpu"]
   - libtorch =={{ version }}=gpu_cuda{{ cuda_compiler_version | replace('.','') }}_*_{{ PKG_BUILDNUM }}    # [(gpu_variant or "").startswith("cuda")]
   - libtorch =={{ version }}=gpu_mps_*_{{ PKG_BUILDNUM }}                                                   # [gpu_variant == "metal"]
   ```
5. `pytorch` run_exports: replaced `pin_subpackage('libtorch', max_pin='x.x')` with literal `libtorch >={{ version }},<2.13.0a0`.

## Target branch

**`main312`** (not `master`). master is already at `d2a75f1` with PR #97 (py3.14-only) merged.

## Companion PR

PR #105 covers py3.10/3.11 → `main310`. The recipe diff is byte-identical to this one except for the top-level skip selector.

## Net new artifacts (32 files)

16 build slots × 2 py-versions = 32 pytorch `.conda` files.

## Test plan
- [ ] PBP graph generates without errors
- [ ] All 32 build slots × 2 py = 32 pytorch builds succeed
- [ ] Tests pass (smoke + run_test) for both py3.12 and py3.13 across all platforms
- [ ] Release task publishes all 32 pytorch artifacts to pkgs/main
- [ ] After both republish PRs released: `conda search pytorch=2.12.0 -c pkgs/main` shows py310 + py311 + py312 + py313 + py314 entries (16 each on linux-64/win-64; 2 each on linux-aarch64/osx-arm64) — 80 total