### PR TITLE
PKG-15922: rebuild pytorch 2.12.0 against libprotobuf 7.35.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -615,10 +615,39 @@ outputs:
         - python -c "import torch; torch.tensor(1).to('cpu').numpy(); print('numpy support enabled!!!')"
         - test -f $PREFIX/lib/libtorch_python${SHLIB_EXT}     # [unix]
 
-  - name: pytorch-{{ "cpu" if gpu_variant == "cpu" else "gpu" }}
+  # Two static-name wrapper outputs (formerly a single dynamic-name output).
+  # Splitting fixes two issues at once:
+  #   1. PBP graph-submitter rejected the single-output form as duplicate test
+  #      tasks on x86 platforms — the wrapper's build.string had no blas_impl,
+  #      so mkl and openblas variants rendered identical PKG_HASH.
+  #   2. The dynamic-name form emitted BOTH pytorch-cpu and pytorch-gpu wrappers
+  #      from the same variant — and the pytorch-gpu wrapper's test env then
+  #      couldn't resolve `pytorch =...=gpu*` → `__cuda` on the CPU test pool.
+  # Static names + selector-gated skip on gpu_variant keeps conda-build's
+  # variant tracking honest: one wrapper per (gpu_variant, blas=openblas) pair.
+  - name: pytorch-cpu
+    build:
+      skip: true  # [gpu_variant != "cpu" or blas_impl == "mkl"]
     requirements:
       run:
-        - pytorch ={{ version }}={{ "cpu" if gpu_variant == "cpu" else "gpu" }}* # NB pinning exact=True will also pin to the python version
+        - pytorch ={{ version }}=cpu*
+    test:
+      imports:
+        - torch
+
+  - name: pytorch-gpu
+    build:
+      skip: true  # [gpu_variant == "cpu" or blas_impl == "mkl"]
+    requirements:
+      # `cuda_compiler` in build has zero function for this metapackage BUT it
+      # forces PBP to route the wrapper's test task to a GPU worker pool that
+      # provides the `__cuda` virtual package. Without it the wrapper's test
+      # env can't resolve (libtorch's `run: [__cuda]` is unsatisfiable on the
+      # CPU test pool). See memory/reference_pbp-gpu-worker-routing.md.
+      build:
+        - {{ compiler('cuda') }}                # [gpu_variant == "cuda"]
+      run:
+        - pytorch ={{ version }}=gpu*
     test:
       imports:
         - torch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.12.0" %}
 # Set the RC number to build release candidates. Set to None otherwise.
 {% set rc = None %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # Single source of truth: the commit SHA the v{{ version }} tag points at.
 # Drives BOTH the source git_rev AND the smoke_test fetches below — one SHA
@@ -154,10 +154,10 @@ requirements:
     - libuv     # [win]
     - cmake
     - ninja-base
-    - libabseil
+    - libabseil 20260526.0
     # Keep libprotobuf here so that a compatibile version
     # of protobuf is installed between build and host
-    - libprotobuf
+    - libprotobuf 7.35.1
     - make      # [linux]
   host:
     # GPU requirements
@@ -211,8 +211,8 @@ requirements:
     - intel-openmp {{ mkl }}         # [blas_impl == "mkl"]
     - libgomp                        # [linux and blas_impl == "openblas"]
     - llvm-openmp                    # [osx and not (blas_impl == "mkl")]
-    - libabseil {{ libabseil }}
-    - libprotobuf {{ libprotobuf }}
+    - libabseil 20260526.0
+    - libprotobuf 7.35.1
     # sleef 3.9.0 OpenMP-flavor variant must match parent env's runtime to
     # avoid mismatched DT_NEEDED on torch_cpu:
     #   linux+openblas → libgomp     (AR libgcc *_gnu mutex)
@@ -380,7 +380,7 @@ outputs:
         - ninja-base
         # Keep libprotobuf here so that a compatibile version
         # of protobuf is installed between build and host
-        - libprotobuf
+        - libprotobuf 7.35.1
         - make      # [linux]
       host:
         # GPU requirements
@@ -428,8 +428,8 @@ outputs:
         - intel-openmp {{ mkl }}      # [blas_impl == "mkl"]
         - libgomp                     # [linux and blas_impl == "openblas"]
         - llvm-openmp                 # [osx and not (blas_impl == "mkl")]
-        - libabseil
-        - libprotobuf {{ libprotobuf }}
+        - libabseil 20260526.0
+        - libprotobuf 7.35.1
         # sleef: see libtorch host above for the 3.9.0 variant-matching rationale.
         - sleef 3.9.0 *libgomp*       # [linux and blas_impl != "mkl"]
         - sleef 3.9.0 *llvm_openmp*   # [osx]


### PR DESCRIPTION
## Version
- `pytorch` `2.12.0` (rebuild, base build `0` → `1`)

## Destination channel
- `main`

## Links
- Jira: [PKG-15922](https://anaconda.atlassian.net/browse/PKG-15922)
- PyPI: N/A
- GitHub: [pytorch/pytorch v2.12.0](https://github.com/pytorch/pytorch/releases/tag/v2.12.0)

## Explanation of changes
- Rebuilds `pytorch` / `libtorch` 2.12.0 against hardcoded `libabseil` `20260526.0` and `libprotobuf` `7.35.1` for the protobuf migration epic.
- Split the single dynamic-name wrapper (`pytorch-{cpu|gpu}`) into two static-name outputs (`pytorch-cpu`, `pytorch-gpu`), adding `{{ compiler('cuda') }}` to the gpu wrapper's build reqs so PBP routes its test to a GPU worker (else `nothing provides __cuda`). Fixes the wrapper test failures; same fix carried by the 2.13 PRs (#108/#109/#110). Wrappers carry no protobuf link, so this is version-independent.

## CI note
- The only red is win-64: builds `claim-expired` on the `windows-server-2025-amd64` pool ([SIR-3657](https://anaconda.atlassian.net/browse/SIR-3657)) — a PBP worker-daemon infra bug, **not** the recipe. All other platforms (linux-64, linux-aarch64, osx-arm64) are green, including every wrapper test. Win-64 will clear once SIR-3657 is resolved (or via graph reruns on healthy workers).

[PKG-15922]: https://anaconda.atlassian.net/browse/PKG-15922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[SIR-3657]: https://anaconda.atlassian.net/browse/SIR-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ